### PR TITLE
Fix for padding on facets

### DIFF
--- a/aristotle_mdr/static/aristotle_mdr/aristotle.less
+++ b/aristotle_mdr/static/aristotle_mdr/aristotle.less
@@ -553,3 +553,7 @@ background: repeating-linear-gradient(
     padding-top:10px;
     border-top:1px solid lightgray;
 }
+
+.facets{
+    padding: 0px;
+}


### PR DESCRIPTION
On the search page there is an error in the facet sidebar, this fix removes the padding.