### PR TITLE
Fix Issue #500: Modify queryset to filter out unwanted items

### DIFF
--- a/aristotle_mdr/views/user_pages.py
+++ b/aristotle_mdr/views/user_pages.py
@@ -278,7 +278,6 @@ class CreatedItemsListView(ListView):
             statuses__isnull=True,
             review_requests__isnull=True
         )
-        #return MDR._concept.objects.filter(submitter=self.request.user)  # ,statuses=None,review_requests=None)
 
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context

--- a/aristotle_mdr/views/user_pages.py
+++ b/aristotle_mdr/views/user_pages.py
@@ -273,7 +273,12 @@ class CreatedItemsListView(ListView):
         return super(CreatedItemsListView, self).dispatch(*args, **kwargs)
 
     def get_queryset(self, *args, **kwargs):
-        return MDR._concept.objects.filter(submitter=self.request.user)  # ,statuses=None,review_requests=None)
+        return MDR._concept.objects.filter(
+            submitter=self.request.user,
+            statuses__isnull=True,
+            review_requests__isnull=True
+        )
+        #return MDR._concept.objects.filter(submitter=self.request.user)  # ,statuses=None,review_requests=None)
 
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context


### PR DESCRIPTION
Change sandbox queryset to filter for no reviews and no statuses and added a test.
I'm not sure if the filter is correct, as it doesn't correspond to the "published" or "registered" in the issue. Please advise if not correct. Thanks.