### PR TITLE
v.1.4.2 Improvements to bulk downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ services:
 env:
   - DJANGO_VERSION='1.8,<1.9' DB=sqlitefile   SEARCH=whoosh
   - DJANGO_VERSION='1.8,<1.9' DB=postgres     SEARCH=whoosh
-  - DJANGO_VERSION='1.8,<1.9' DB=mysql        SEARCH=whoosh
   - DJANGO_VERSION='1.8,<1.9' DB=sqlitefile   SEARCH=elasticsearch
   - DJANGO_VERSION='1.8,<1.9' DB=postgres     SEARCH=elasticsearch
+  # Possible failures:
+  - DJANGO_VERSION='1.8,<1.9' DB=mysql        SEARCH=whoosh
   - DJANGO_VERSION='1.8,<1.9' DB=mysql        SEARCH=elasticsearch
+  - DJANGO_VERSION='1.8,<1.9' DB=sqlitefile   SEARCH=whoosh  VARIANT=haystack
+  - DJANGO_VERSION='1.8,<1.9' DB=sqlitefile   SEARCH=elasticsearch  VARIANT=haystack
 #   - DJANGO_VERSION='1.10,<1.11' DB=sqlitememory
 #   - DJANGO_VERSION='1.10,<1.11' DB=sqlitefile
 #   - DJANGO_VERSION='1.10,<1.11' DB=postgres
@@ -73,3 +76,5 @@ matrix:
   allow_failures:
     - env: DJANGO_VERSION='1.8,<1.9' DB=mysql        SEARCH=whoosh
     - env: DJANGO_VERSION='1.8,<1.9' DB=mysql        SEARCH=elasticsearch
+    - env: DJANGO_VERSION='1.8,<1.9' DB=sqlitefile   SEARCH=elasticsearch  VARIANT=haystack
+    - env: DJANGO_VERSION='1.8,<1.9' DB=sqlitefile   SEARCH=whoosh  VARIANT=haystack

--- a/aristotle_mdr/__init__.py
+++ b/aristotle_mdr/__init__.py
@@ -4,7 +4,7 @@ default_app_config = 'aristotle_mdr.apps.AristotleMDRConfig'
 __version_info__ = {
     'major': 1,
     'minor': 4,
-    'micro': 1,
+    'micro': 2,
     'releaselevel': 'final',
     'serial': 0
 }

--- a/aristotle_mdr/contrib/browse/views.py
+++ b/aristotle_mdr/contrib/browse/views.py
@@ -112,7 +112,7 @@ class BrowseConcepts(AppBrowser):
         for slot_name, values in slots.items():
             try:
                 queryset = queryset.filter(
-                    slots__type__slot_name=k,
+                    slots__type__slot_name=slot_name,
                     slots__value__in=values,
                 )
             except FieldError:

--- a/aristotle_mdr/downloader.py
+++ b/aristotle_mdr/downloader.py
@@ -18,7 +18,7 @@ item_register = {
 }
 
 
-def render_to_pdf(template_src, context_dict):
+def render_to_pdf(template_src, context_dict, debug_as_html=False):
     # If the request template doesnt exist, we will give a default one.
     template = select_template([
         template_src,
@@ -26,6 +26,8 @@ def render_to_pdf(template_src, context_dict):
     ])
     context = Context(context_dict)
     html = template.render(context)
+    if debug_as_html:
+        return HttpResponse(html)
     result = StringIO.StringIO()
     pdf = pisa.pisaDocument(
         StringIO.StringIO(html.encode("UTF-8")),
@@ -131,6 +133,8 @@ def bulk_download(request, download_type, items, title=None, subtitle=None):
     if download_type == "pdf":
         subItems = []
 
+        debug_as_html = bool(request.GET.get('html', ''))
+
         return render_to_pdf(
             template,
             {
@@ -139,5 +143,6 @@ def bulk_download(request, download_type, items, title=None, subtitle=None):
                 'items': items,
                 'included_items': sorted([(k, v) for k, v in item_querysets.items()], key=lambda (k, v): k._meta.model_name),
                 'pagesize': request.GET.get('pagesize', page_size),
-            }
+            },
+            debug_as_html=debug_as_html
         )

--- a/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/bulk_download.html
+++ b/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/bulk_download.html
@@ -1,4 +1,4 @@
-{% load i18n aristotle_help %}
+{% load i18n aristotle_help aristotle_tags %}
 
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -7,7 +7,7 @@
       <meta http-equiv="content-type" content="text/html; charset=UTF-8">
       <style type="text/css">
             * {
-                font-size:12pt;
+                font-size:11pt;
             }
 
             h1 {
@@ -58,7 +58,7 @@
             a {
                 text-decoration: none;
                 color:black;
-                padding:100px;
+                padding-left:1px;
             }
 
             pdftoc {
@@ -82,6 +82,10 @@
             td, td * , th, th *{
                 vertical-align:top;
             }
+            cite {
+                font-style:italic;
+            }
+
             @page {
                 size: {{ pagesize }};
                 margin: 1cm;
@@ -130,7 +134,9 @@
                     {% endif %}
                 {% endwith %}
                 {% for item in dict.qs.all %}
-                    {% include 'aristotle_mdr/downloads/pdf/inline/managedContent.html' with item=item.item %}
+                    <div style="page-break-after:always;">
+                        {% include item|template_path:'pdf,inline' with item=item.item %}
+                    </div>
                 {% endfor %}
             {% endfor %}
             <div>

--- a/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/inline/objectClass.html
+++ b/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/inline/objectClass.html
@@ -1,4 +1,0 @@
-{% extends "aristotle_mdr/downloads/pdf/inline/managedContent.html" %}
-
-{% block objSpecific %}
-{% endblock %}

--- a/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/inline/objectclass.html
+++ b/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/inline/objectclass.html
@@ -1,4 +1,0 @@
-{% extends "aristotle_mdr/downloads/pdf/inline/managedContent.html" %}
-
-{% block objSpecific %}
-{% endblock %}

--- a/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/inline/property.html
+++ b/aristotle_mdr/templates/aristotle_mdr/downloads/pdf/inline/property.html
@@ -1,4 +1,0 @@
-{% extends "aristotle_mdr/downloads/pdf/inline/managedContent.html" %}
-
-{% block objSpecific %}
-{% endblock %}

--- a/aristotle_mdr/tests/main/test_bulk_actions.py
+++ b/aristotle_mdr/tests/main/test_bulk_actions.py
@@ -14,10 +14,10 @@ class BulkActionsTest(utils.LoggedInViewPages):
 
         # There would be too many tests to test every item type against every other
         # But they all have identical logic, so one test should suffice
-        self.item1 = models.ObjectClass.objects.create(name="OC1", workgroup=self.wg1)
-        self.item2 = models.ObjectClass.objects.create(name="OC2", workgroup=self.wg1)
-        self.item3 = models.ObjectClass.objects.create(name="OC3", workgroup=self.wg1)
-        self.item4 = models.Property.objects.create(name="Prop4", workgroup=self.wg2)
+        self.item1 = models.ObjectClass.objects.create(name="OC1", definition="OC1 definition", workgroup=self.wg1)
+        self.item2 = models.ObjectClass.objects.create(name="OC2", definition="OC2 definition", workgroup=self.wg1)
+        self.item3 = models.ObjectClass.objects.create(name="OC3", definition="OC3 definition", workgroup=self.wg1)
+        self.item4 = models.Property.objects.create(name="Prop4", definition="Prop4 definition", workgroup=self.wg2)
 
 
 class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
@@ -35,6 +35,20 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self.editor.profile.favourites.count(), 2)
+
+
+    def test_bulk_add_favourite_on_permitted_items_by_anonymous(self):
+        self.logout()
+
+        response = self.client.post(
+            reverse('aristotle:bulk_action'),
+            {
+                'bulkaction': 'add_favourites',
+                'items': [self.item1.id, self.item2.id],
+            }
+        )
+        self.assertRedirects(response,reverse('friendly_login')+"?next="+reverse('aristotle:bulk_action'))
+        self.assertEqual(response.status_code, 302)
 
     def test_bulk_add_favourite_on_forbidden_items(self):
         self.login_editor()
@@ -389,7 +403,6 @@ class BulkDownloadTests(BulkActionsTest, TestCase):
     def test_bulk_pdf_download_on_forbidden_items(self):
         self.login_editor()
 
-        self.assertEqual(self.editor.profile.favourites.count(), 0)
         response = self.client.post(
             reverse('aristotle:bulk_action'),
             {
@@ -403,3 +416,70 @@ class BulkDownloadTests(BulkActionsTest, TestCase):
         )
         self.assertEqual(len(response.redirect_chain), 1)
         self.assertEqual(response.redirect_chain[0][1], 302)
+
+
+    def test_bulk_pdf_download_on_forbidden_items_by_anonymous_user(self):
+        self.logout()
+
+        response = self.client.post(
+            reverse('aristotle:bulk_action'),
+            {
+                'bulkaction': 'bulk_download',
+                'items': [self.item1.id, self.item4.id],
+                "title": "The title",
+                "download_type": self.download_type,
+                'confirmed': 'confirmed',
+            },
+            follow=True
+        )
+        self.assertEqual(len(response.redirect_chain), 1)
+        self.assertEqual(response.redirect_chain[0][1], 302)
+
+        response = self.client.post(
+            reverse('aristotle:bulk_action'),
+            {
+                'bulkaction': 'bulk_download',
+                'items': [self.item1.id, self.item4.id],
+                "title": "The title",
+                "download_type": self.download_type,
+                'confirmed': 'confirmed',
+            },
+        )
+        self.assertRedirects(
+            response,
+            reverse(
+                'aristotle:bulk_download',
+                kwargs={
+                    "download_type": self.download_type,
+                }
+            )+"?title=The%20title"+"&items=%s&items=%s"%(self.item1.id, self.item4.id)
+        )
+
+    def test_content_exists_in_bulk_pdf_download_on_permitted_items(self):
+        self.login_editor()
+
+        self.item5 = models.DataElementConcept.objects.create(name="DEC1", definition="DEC5 definition", objectClass=self.item2, workgroup=self.wg1)
+
+        response = self.client.get(
+            reverse(
+                'aristotle:bulk_download',
+                kwargs={
+                    "download_type": self.download_type,
+                }
+            ),
+            {
+                "items": [self.item1.id, self.item5.id],
+                "title": "The title",
+                "html": True  # Force HTML to debug content
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.item1.name)
+        self.assertContains(response, self.item2.name)  # Will be in as its a component of DEC5
+        self.assertContains(response, self.item5.name)
+
+        self.assertContains(response, self.item1.definition)
+        self.assertContains(response, self.item2.definition)  # Will be in as its a component of DEC5
+        self.assertContains(response, self.item5.definition)
+

--- a/aristotle_mdr/tests/settings/settings.py
+++ b/aristotle_mdr/tests/settings/settings.py
@@ -46,10 +46,20 @@ if 'TRAVIS' in os.environ:
 
     if os.environ.get('SEARCH') == 'whoosh':
         print("Running TRAVIS-CI test-suite with whoosh")
-        from aristotle_mdr.tests.settings.templates.search.whoosh import HAYSTACK_CONNECTIONS
+        if os.environ.get('VARIANT') == 'haystack':
+            print("Vanilla haystack variant")
+            from aristotle_mdr.tests.settings.templates.search.haystack_whoosh import HAYSTACK_CONNECTIONS
+        else:
+            print("Aristotle specific variant")
+            from aristotle_mdr.tests.settings.templates.search.whoosh import HAYSTACK_CONNECTIONS
     elif os.environ.get('SEARCH') == 'elasticsearch':
         print("Running TRAVIS-CI test-suite with elasticsearch")
-        from aristotle_mdr.tests.settings.templates.search.elasticsearch import HAYSTACK_CONNECTIONS
+        if os.environ.get('VARIANT') == 'haystack':
+            print("Vanilla haystack variant")
+            from aristotle_mdr.tests.settings.templates.search.haystack_elasticsearch import HAYSTACK_CONNECTIONS
+        else:
+            print("Aristotle specific variant")
+            from aristotle_mdr.tests.settings.templates.search.elasticsearch import HAYSTACK_CONNECTIONS
 
 if 'ARISTOTLE_DEV_SKIP_MIGRATIONS' in os.environ or os.environ.get('DB') == 'mysql':  # pragma: no cover
     print("Skipping migrations")

--- a/aristotle_mdr/tests/settings/templates/search/haystack_elasticsearch.py
+++ b/aristotle_mdr/tests/settings/templates/search/haystack_elasticsearch.py
@@ -1,0 +1,7 @@
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+        'URL': 'http://127.0.0.1:9200/',
+        'INDEX_NAME': 'haystack',
+    },
+}

--- a/aristotle_mdr/tests/settings/templates/search/haystack_whoosh.py
+++ b/aristotle_mdr/tests/settings/templates/search/haystack_whoosh.py
@@ -1,0 +1,10 @@
+import os
+
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        #'ENGINE': 'aristotle_mdr.contrib.search_backends.facetted_whoosh.FixedWhooshEngine',
+        'PATH': os.path.join(os.path.dirname(__file__), 'whoosh_index'),
+        'INCLUDE_SPELLING': True,
+    },
+}

--- a/aristotle_mdr/utils/utils.py
+++ b/aristotle_mdr/utils/utils.py
@@ -42,6 +42,15 @@ def get_download_template_path_for_item(item, download_type, subpath=''):
         template = "%s/downloads/%s/%s/%s.html" % (app_label, download_type, subpath, model_name)
     else:
         template = "%s/downloads/%s/%s.html" % (app_label, download_type, model_name)
+
+    from django.template.loader import get_template
+    from django.template import TemplateDoesNotExist
+    try:
+        get_template(template)
+    except TemplateDoesNotExist:
+        # This is ok. If a template doesn't exists pass a default one
+        # Maybe in future log an error?
+        template = "%s/downloads/%s/%s/%s.html" % ("aristotle_mdr", download_type, subpath, "managedContent")
     return template
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'docutils',
 
         #Search requirements
-        'django-haystack>=2.5.0,<=2.6.0',
+        'django-haystack==2.5.0',
         'Whoosh',
 
         #Rich text editors


### PR DESCRIPTION
* Improvements to bulk downloads

* Fixed permissions for bulk actions fixes #538
* Improve bulk download customisation, fixes #537
* Removed unnecessary pdf templates
* Increase test coverage
* Add vanilla fail variants for whoosh search engines
* Improved browse faceting fixes #533 (#534)

* pep

* fixes #537

* pep

* add haystack elasticsearch, because the new version has broken stuff

* change haystack requirement

* fix haystack import

* fix haystack import

* remove debug print

* test tweaks