### PR TITLE
Fixed Slot usage in pdf template and index to work with new Slot models

### DIFF
--- a/aristotle_mdr/contrib/slots/templates/aristotle_mdr/slots/pdf/slots_display.html
+++ b/aristotle_mdr/contrib/slots/templates/aristotle_mdr/slots/pdf/slots_display.html
@@ -20,7 +20,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for slot in item.slots.all|order_by:'slot_name' %}
+        {% for slot in item.slots.all|order_by:'name' %}
         <tr>
             <td>
                 {{ slot.name }}
@@ -30,7 +30,7 @@
                 {{ slot.value|linebreaks }}
             </td>
             <td>
-                <a href="{% url 'aristotle_slots:similar_slots' slot.type.id %}?value={{slot.value}}">
+                <a href="{% url 'aristotle_slots:similar_slots' slot.name %}?value={{slot.value}}">
                 {% count_similar request.user slot %}
                 </a>
             </td>

--- a/aristotle_mdr/downloader.py
+++ b/aristotle_mdr/downloader.py
@@ -61,6 +61,7 @@ def download(request, download_type, item):
                 'tableOfContents': len(subItems) > 0,
                 'view': request.GET.get('view', '').lower(),
                 'pagesize': request.GET.get('pagesize', page_size),
+                'request': request,
             }
         )
 

--- a/aristotle_mdr/templates/search/indexes/aristotle_mdr/managedobject_text.txt
+++ b/aristotle_mdr/templates/search/indexes/aristotle_mdr/managedobject_text.txt
@@ -7,5 +7,5 @@
 {% for state in object.statuses.all %}{{ state.state_name }} {% endfor %}
 
 {% for slot in object.slots.all %}
-{{slot.type.slot_name}} {{slot.value}}
+{{slot.name}} {{slot.value}}
 {% endfor %}


### PR DESCRIPTION
Modified slot_display template to use new Slot models introduced on v1.5
Added request to downloaded context to be able to render the counter of similar slots.
Fixed index generation to include the slot name using new Slot Models.

This is a continuation of PR: #634 