### PR TITLE
Fixes for autocomplete light plugin and bootstrap modals

### DIFF
--- a/aristotle_mdr/static/autocomplete_light/select2.js
+++ b/aristotle_mdr/static/autocomplete_light/select2.js
@@ -1,6 +1,6 @@
 /*
 
-Modification of 
+Modification of
 https://github.com/yourlabs/django-autocomplete-light/blob/63abc0308e1cf308233538d9ed3e969b51f08fc4/src/dal_select2/static/autocomplete_light/select2.js
 
 */
@@ -126,7 +126,7 @@ https://github.com/yourlabs/django-autocomplete-light/blob/63abc0308e1cf30823353
         });
 
     });
-
+    window.__dal__initListenerIsSet = true;
     // Remove this block when this is merged upstream:
     // https://github.com/select2/select2/pull/4249
     $(document).on('DOMSubtreeModified', '[data-autocomplete-light-function=select2] option', function() {

--- a/aristotle_mdr/templates/aristotle_mdr/concepts/dataElement.html
+++ b/aristotle_mdr/templates/aristotle_mdr/concepts/dataElement.html
@@ -95,6 +95,7 @@
         </dl>
     {% endif %}
 {% endif %}
+{% bootstrap_modal 'fk_editor' size='md' %}
 {% endblock %}
 
 {% block relationships %}


### PR DESCRIPTION
 * Added missing bootstrap modal on dataElement template to enable `Edit/Add` links
![dataelementmodal](https://user-images.githubusercontent.com/381332/30745662-6bda13aa-9f7d-11e7-872c-e9e4d4bb4eee.png)

 * Initialization fixes for latest django-autocomplete-light plugin. In version `3.2.10` a conditional was added on the initialization: https://github.com/yourlabs/django-autocomplete-light/commit/74627c5d771b10eaa2c55f95406379b0cf047aba