### PR TITLE
Added JS fixes, on advanced editor when using bootstrap modals

### DIFF
--- a/aristotle_mdr/templates/aristotle_mdr/actions/advanced_editor.html
+++ b/aristotle_mdr/templates/aristotle_mdr/actions/advanced_editor.html
@@ -8,6 +8,20 @@
     <link rel="stylesheet" href="{% static 'aristotle_mdr/aristotle_search.less'|compile %}" />
     {% if request.is_ajax %}
         {{ form.media }}
+        {# Fixes to load and init scripts dynamically on bootstrap modals #}
+        <script type="text/javascript">
+        $(function() {
+            // Load autocomplete script with jquery for compatibility
+            $.ajax({
+              url: "{% static 'autocomplete_light/autocomplete.init.js' %}",
+              dataType: "script"
+            });
+            // Trigger DOMContentLoaded event
+            var DOMContentLoaded_event = document.createEvent("Event")
+            DOMContentLoaded_event.initEvent("DOMContentLoaded", true, true)
+            window.document.dispatchEvent(DOMContentLoaded_event);
+        });
+        </script>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
**Problem:**
when loading the advanced editor, on a bootstrap modal, two plugins were not initialized: autocomplete-light, ckeditor

**Fixes:**
Loading the autocomplete.init.js with JQuery, on modal display, to initialize the autocomplete-light plugin.
Triggering DOMContentLoaded event to initialize the ckeditor when the bootstrap modal is loaded.

**Autocomplete-light problem**
select2 plugin not loaded on advanced editor (screenshot taken from registry.aristotlemetadata.com):
![advancededitorautocompleteproblem](https://user-images.githubusercontent.com/381332/30746365-00259032-9f80-11e7-91de-a308d87209b4.png)

**ckeditor problem**
ckeditor is not loading on my environments (`Django 1.8`, `ckeditor 5.3.0`, latest Aristotle) is not loading on bootstrap modal. But I noticed that is working on registry.aristotlemetadata.com not sure which versions are used on that site.