### PR TITLE
Better description display for searchItem on Search results

### DIFF
--- a/aristotle_mdr/templates/search/searchItem.html
+++ b/aristotle_mdr/templates/search/searchItem.html
@@ -3,7 +3,7 @@
 <a href="{% url 'aristotle:item' item.id %}">{{ item.name }}</a>
 <span class="item_type">({{ item.get_verbose_name }})</span>
 <p>
-    {{ item.definition|truncatewords:20|striptags }}
+    {{ item.definition|striptags|safe|truncatewords:20 }}
 </p>
 <div class="attrs">
     <span class="attr">


### PR DESCRIPTION
Some characters were escaped on the search results:

![](https://user-images.githubusercontent.com/28066062/31022925-58cdc726-a508-11e7-841d-b0d1c63d206b.png)

To avoid this we can follow the same as idea as in [concept_list_details.html](https://github.com/aristotle-mdr/aristotle-metadata-registry/blob/e1b88f24b0c6934b65e99425c3e462710b3a8a5b/aristotle_mdr/templates/aristotle_mdr/helpers/concept_list_details.html#L2) by first `striptags`, then `safe` and finally `truncatewords`
