### PR TITLE
New User Signup

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/forms.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/forms.py
@@ -43,7 +43,7 @@ class UserInvitationForm(FormRequestMixin, forms.Form):
 
 class SelfInviteForm(forms.Form):
 
-    email = forms.EmailField()
+    email = forms.EmailField(widget=forms.TextInput(attrs={'class':'form-control'}))
 
 
 class AristotleUserRegistrationForm(UserRegistrationForm):

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/forms.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/forms.py
@@ -41,6 +41,11 @@ class UserInvitationForm(FormRequestMixin, forms.Form):
         self.emails = emails
 
 
+class SelfInviteForm(forms.Form):
+
+    email = forms.EmailField()
+
+
 class AristotleUserRegistrationForm(UserRegistrationForm):
 
     def __init__(self, *args, **kwargs):

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
@@ -170,7 +170,7 @@ class AristotleSignupBackend(AristotleInvitationBackend):
             regsettings = aristotle_settings['registry']
             # Check if user self signup is enabled
             signup_enabled = regsettings.get('self_signup_enabled', True)
-            allowed_suffixes = regsettings.get('self_signup_emails', None)
+            allowed_suffixes = regsettings.get('self_signup_emails', None).split(',')
 
         if not signup_enabled:
             return render(
@@ -201,7 +201,7 @@ class AristotleSignupBackend(AristotleInvitationBackend):
         valid = False
 
         for suffix in suffixes:
-            if email.endswith(suffix):
+            if email.endswith(suffix.lstrip()):
                 valid = True
 
         return valid

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
@@ -166,6 +166,9 @@ class AristotleSignupBackend(AristotleInvitationBackend):
     def create_view(self, request):
         aristotle_settings = fetch_aristotle_settings()
 
+        if request.user.is_authenticated:
+            return HttpResponseRedirect(reverse('aristotle_mdr:userHome'))
+
         if 'registry' in aristotle_settings:
             regsettings = aristotle_settings['registry']
             # Check if user self signup is enabled

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
@@ -32,6 +32,7 @@ class BaseAristotleInvitationBackend(InvitationBackend):
     """
 
     form_class = forms.AristotleUserRegistrationForm
+    accept_url_name = 'aristotle-user:registry_invitations_register'
 
     def get_success_url(self):
         return reverse('friendly_login') + '?welcome=true'
@@ -39,7 +40,7 @@ class BaseAristotleInvitationBackend(InvitationBackend):
     def get_urls(self):
         return [
             url(r'^accept/(?P<user_id>[\d]+)-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-                view=self.activate_view, name="registry_invitations_register"),
+                view=self.activate_view, name=self.accept_url_name),
             url(r'^$', view=self.invite_view(), name="registry_invitations_create"),
         ]
 
@@ -113,7 +114,7 @@ class BaseAristotleInvitationBackend(InvitationBackend):
             reply_to = from_email
 
         headers = {'Reply-To': reply_to}
-        kwargs.update({'sender': sender, 'user': user})
+        kwargs.update({'sender': sender, 'user': user, 'accept_url_name': self.accept_url_name})
 
         subject_template = loader.get_template(subject_template)
         body_template = loader.get_template(body_template)
@@ -151,12 +152,13 @@ class AristotleInvitationBackend(BaseAristotleInvitationBackend):
 class AristotleSignupBackend(AristotleInvitationBackend):
 
     registration_form_template = "aristotle_mdr/users_management/self_invite.html"
+    accept_url_name = 'aristotle-user:signup_register'
 
     def get_urls(self):
         return [
             url(r'^(?P<user_id>[\d]+)-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
                 view=self.activate_view, name="signup_register"),
-            url(r'^$', view=self.create_view, name="signup_create"),
+            url(r'^$', view=self.create_view, name=self.accept_url_name),
         ]
 
     def create_view(self, request):

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/org_backends.py
@@ -34,7 +34,7 @@ class BaseAristotleInvitationBackend(InvitationBackend):
     """
 
     form_class = forms.AristotleUserRegistrationForm
-    accept_url_name = 'aristotle-user:registry_invitations_register'
+    accept_url_name = 'registry_invitations_register'
 
     def get_success_url(self):
         return reverse('friendly_login') + '?welcome=true'
@@ -116,7 +116,7 @@ class BaseAristotleInvitationBackend(InvitationBackend):
             reply_to = from_email
 
         headers = {'Reply-To': reply_to}
-        kwargs.update({'sender': sender, 'user': user, 'accept_url_name': self.accept_url_name})
+        kwargs.update({'sender': sender, 'user': user, 'accept_url_name': 'aristotle-user:' + self.accept_url_name})
 
         subject_template = loader.get_template(subject_template)
         body_template = loader.get_template(body_template)
@@ -154,7 +154,7 @@ class AristotleInvitationBackend(BaseAristotleInvitationBackend):
 class AristotleSignupBackend(AristotleInvitationBackend):
 
     registration_form_template = "aristotle_mdr/users_management/self_invite.html"
-    accept_url_name = 'aristotle-user:signup_register'
+    accept_url_name = 'signup_register'
 
     def get_urls(self):
         return [

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/newuser/email/activation_body.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/newuser/email/activation_body.html
@@ -2,8 +2,8 @@ Your metadata registry "{{ registry.name|safe }}" is almost ready.
 
 To complete registration, follow the link below to create your user account.
 
-<a href="{{scheme}}://{{ registry.get_absolute_url }}{% url "invitations_register" user.id token %}">
-{{scheme}}://{{ registry.get_absolute_url }}{% url "invitations_register" user.id token %}
+<a href="{{scheme}}://{{ registry.get_absolute_url }}{% url accept_url_name user.id token %}">
+{{scheme}}://{{ registry.get_absolute_url }}{% url accept_url_name user.id token %}
 </a>
 
 Once you have entered your details, your registry is ready to go!

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/newuser/email/invitation_body.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/newuser/email/invitation_body.html
@@ -2,6 +2,6 @@ You've been invited to join the {{ config.SITE_NAME }} Metadata Registry.
 
 Follow this link to create your account.
 
- {{request.scheme}}://{{ request.META.HTTP_HOST }}{% url "aristotle-user:registry_invitations_register" user_id token %}
+ {{request.scheme}}://{{ request.META.HTTP_HOST }}{% url accept_url_name user_id token %}
 
 If you are unsure about this link please contact the sender.

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
@@ -3,12 +3,16 @@
 {% block title %}Signup{% endblock %}
 
 {% block content %}
+
+  {% if config.registry.self_signup_message %}
+  <h1>{{ config.registry.self_signup_message|escape }}</h1>
+  {% endif %}
+
   {% if message %}
   <h2>{{ message }}</h2>
   {% endif %}
 
   {% if form %}
-  <h1>Signup to the registry</h1>
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
@@ -4,26 +4,44 @@
 
 {% block content %}
 
-  {% if message %}
-    <h2>{{ message }}</h2>
-  {% else %}
-    {% if config.registry.self_signup_message %}
-      <h1>{{ config.registry.self_signup_message|escape }}</h1>
+  <div class="container">
+
+    {% if message %}
+      <h2>{{ message }}</h2>
     {% else %}
-      <h1>Signup</h1>
+      {% if config.registry.self_signup_message %}
+        <h1>{{ config.registry.self_signup_message|escape }}</h1>
+      {% else %}
+        <h1>Signup</h1>
+      {% endif %}
     {% endif %}
-  {% endif %}
 
-  {% if form %}
-  <form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <input class="btn btn-primary" type="submit" value="Submit" />
-  </form>
-  {% endif %}
+    <div class="row">
+      <div class="col-md-4">
 
-  <p>
-  <a href="{% url 'aristotle_mdr:home' %}" class="btn btn-default">Back</a>
-  </p>
+        {% if form %}
+        <form method="post">
+          {% csrf_token %}
+          {% for field in form %}
+          <div class="form-group">
+            <p class="bg-danger">{{ field.errors }}</p>
+            <p>{{ field.label_tag }}</p>
+            <p>{{ field }}</p>
+            {% if field.help_text %}
+              <p class="help">{{ field.help_text|safe }}</p>
+            {% endif %}
+          </div>
+          {% endfor %}
+          <input class="btn btn-primary" type="submit" value="Submit" />
+          <a href="{% url 'aristotle_mdr:home' %}" class="btn btn-default">Back</a>
+        </form>
+        {% else %}
+          <a href="{% url 'aristotle_mdr:home' %}" class="btn btn-default">Back</a>
+        {% endif %}
+
+      </div>
+    </div>
+
+  </div>
 
 {% endblock %}

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
@@ -3,10 +3,16 @@
 {% block title %}Signup{% endblock %}
 
 {% block content %}
+  {% if message %}
+  <h2>{{ message }}</h2>
+  {% endif %}
+
+  {% if form %}
   <h1>Signup to the registry</h1>
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
     <input type="submit" value="Submit" />
   </form>
+  {% endif %}
 {% endblock %}

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
@@ -4,19 +4,26 @@
 
 {% block content %}
 
-  {% if config.registry.self_signup_message %}
-  <h1>{{ config.registry.self_signup_message|escape }}</h1>
-  {% endif %}
-
   {% if message %}
-  <h2>{{ message }}</h2>
+    <h2>{{ message }}</h2>
+  {% else %}
+    {% if config.registry.self_signup_message %}
+      <h1>{{ config.registry.self_signup_message|escape }}</h1>
+    {% else %}
+      <h1>Signup</h1>
+    {% endif %}
   {% endif %}
 
   {% if form %}
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit" value="Submit" />
+    <input class="btn btn-primary" type="submit" value="Submit" />
   </form>
   {% endif %}
+
+  <p>
+  <a href="{% url 'aristotle_mdr:home' %}" class="btn btn-default">Back</a>
+  </p>
+
 {% endblock %}

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/templates/aristotle_mdr/users_management/self_invite.html
@@ -1,0 +1,12 @@
+{% extends "aristotle_mdr/base.html" %}
+
+{% block title %}Signup{% endblock %}
+
+{% block content %}
+  <h1>Signup to the registry</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Submit" />
+  </form>
+{% endblock %}

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/urls.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/urls.py
@@ -4,7 +4,8 @@ from aristotle_mdr.contrib.user_management import views, org_backends
 
 urlpatterns = [
     # url(r'^accounts/signup', views.NewUserSignupView.as_view(), name="new_user_signup"),
-    url(r'^account/registry/invitations/', include(org_backends.NewUserInvitationBackend().get_urls())),
+    url(r'^account/registry/invitations/', include(org_backends.AristotleInvitationBackend().get_urls())),
+    url(r'^account/signup/', org_backends.SelfInviteView.as_view(), name="self_signup"),
     url(r'^account/registry/users/$', views.RegistryOwnerUserList.as_view(), name="registry_user_list"),
     url(r'^account/registry/users/deactivate/(?P<user_pk>\d+)/$', views.DeactivateRegistryUser.as_view(), name="deactivate_user"),
     url(r'^account/registry/users/reactivate/(?P<user_pk>\d+)/$', views.ReactivateRegistryUser.as_view(), name="reactivate_user"),

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/urls.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/user_management/urls.py
@@ -5,7 +5,7 @@ from aristotle_mdr.contrib.user_management import views, org_backends
 urlpatterns = [
     # url(r'^accounts/signup', views.NewUserSignupView.as_view(), name="new_user_signup"),
     url(r'^account/registry/invitations/', include(org_backends.AristotleInvitationBackend().get_urls())),
-    url(r'^account/signup/', org_backends.SelfInviteView.as_view(), name="self_signup"),
+    url(r'^account/signup/', include(org_backends.AristotleSignupBackend().get_urls())),
     url(r'^account/registry/users/$', views.RegistryOwnerUserList.as_view(), name="registry_user_list"),
     url(r'^account/registry/users/deactivate/(?P<user_pk>\d+)/$', views.DeactivateRegistryUser.as_view(), name="deactivate_user"),
     url(r'^account/registry/users/reactivate/(?P<user_pk>\d+)/$', views.ReactivateRegistryUser.as_view(), name="reactivate_user"),

--- a/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_user_management.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_user_management.py
@@ -164,7 +164,6 @@ class UserManagementPages(utils.LoggedInViewPages, TestCase):
         with patch('aristotle_mdr.context_processors.fetch_aristotle_settings', mock_settings):
             response = self.client.get(reverse('aristotle-user:signup_register'))
             self.assertEqual(response.status_code, 200)
-            print(response.content)
             self.assertTrue('Welcome You Can Signup Here' in str(response.content))
 
         mock_settings = MagicMock(return_value={'registry': {'self_signup_enabled': False}})

--- a/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_user_management.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_user_management.py
@@ -2,6 +2,7 @@ from django.test import TestCase, tag, override_settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.core import mail
+from unittest.mock import patch, MagicMock
 
 import aristotle_mdr.tests.utils as utils
 
@@ -148,3 +149,23 @@ class UserManagementPages(utils.LoggedInViewPages, TestCase):
         self.assertTrue(new_user.password)
         self.assertEqual(new_user.short_name, 'Test')
         self.assertEqual(new_user.full_name, 'Test User')
+
+    @tag('runthis')
+    def test_send_registration_invite(self):
+
+        self.logout()
+
+        mock_settings = MagicMock(return_value={'registry': {'self_signup_enabled': False}})
+        with patch('aristotle_mdr.contrib.user_management.org_backends.fetch_aristotle_settings', mock_settings):
+            response = self.client.get(reverse('aristotle-user:signup_register'))
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse('form' in response.context)
+            self.assertTrue('message' in response.context)
+
+        response = self.client.get(reverse('aristotle-user:signup_register'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('form' in response.context)
+
+        #post_response = self.client.post('aristotle-user:signup_register', {'email', 'aintnuffin@example.com'})
+
+


### PR DESCRIPTION
- Adds sign up page at /account/signup
- Settings to disable, restrict emails and display custom message
- Tests for new functionality

Still to do
- Send notification to someone on user creation (who?)
- Link to sign up from somewhere (probably /login/)