### PR TITLE
Bugfix/843 style check on wrong folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
   include:
     - stage: stylecheck
       python: 3.6
-      script: tox -e flake8 --skip-missing-interpreters
+      script: tox -e flake8
 
     - stage: documentation
       python: 3.6

--- a/python/aristotle-metadata-registry/aristotle_mdr/perms.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/perms.py
@@ -105,6 +105,7 @@ def user_can_edit(user, item):
 
     return _can_edit
 
+
 # TODO remove this
 def user_is_editor(user, workgroup=None):
     if user.is_anonymous():

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,5 @@ exclude =
     example_mdr
 show_source = True
 statistics = True
+filename =
+    */aristotle_mdr/*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[flake8]
+ignore =
+    E501,  # max line length
+    E225,  # Missing whitespace around operator
+    E123,  # Closing bracket does not match indentation of opening bracket's line
+    E722,  # bare excepts
+    F401,  # Module imported but unused
+    F841,  # Local variable name is assigned to but never used
+    F403,  #'from module import *' used; unable to detect undefined names
+    F811,  # Redefinition of unused name
+    F821   # Undefined name
+exclude =
+    migrations,
+    tests,
+    example_mdr
+show_source = True
+statistics = True

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,7 @@ deps =
     flake8
 commands=
     flake8 {toxinidir}/wrong/path/python/aristotle-metadata-registry/aristotle_mdr
+skip_missing_interpreters = True
 
 [testenv:docs]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ commands =
 deps =
     flake8
 commands=
-    flake8 {toxinidir}/wrong/path/python/aristotle-metadata-registry/aristotle_mdr
+    flake8
 skip_missing_interpreters = True
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ commands =
 deps =
     flake8
 commands=
-    flake8  --exclude=migrations,tests,example_mdr --ignore=E501,E225,E123,E722,F401,F841,F403,F811,F821 {toxinidir}/python/aristotle_mdr
+    flake8 {toxinidir}/wrong/path/python/aristotle-metadata-registry/aristotle_mdr
 
 [testenv:docs]
 commands=


### PR DESCRIPTION
The run on Travis should detect an error on:

```python
./python/aristotle-metadata-registry/aristotle_mdr/perms.py:109:1: E302 expected 2 blank lines, found 1
def user_is_editor(user, workgroup=None):
^
1     E302 expected 2 blank lines, found 1
```

If it detects correctly is a sign that this is working. After this I will include a wrong path to test if someone change the path and don't update the setup.cfg it should fail too. After the second tests, I will revert this last commit and I will fix the issue with E302 on the `perms.py`.