### PR TITLE
Automatic deselections on change status

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/forms/fields.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/forms/fields.py
@@ -98,7 +98,7 @@ class ReviewChangesChoiceField(ModelMultipleChoiceField):
                     deselections = True
 
             innerdict['perm'] = perms.user_can_change_status(user, concept)
-            innerdict['new_state'] =  {'url': url, 'text': new_state}
+            innerdict['new_state'] = {'url': url, 'text': new_state}
 
             extra_info[concept.id] = innerdict
 

--- a/python/aristotle-metadata-registry/aristotle_mdr/forms/fields.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/forms/fields.py
@@ -15,7 +15,7 @@ class ReviewChangesChoiceField(ModelMultipleChoiceField):
 
     def __init__(self, queryset, static_content, ra, user, **kwargs):
 
-        extra_info = self.build_extra_info(queryset, ra, user, static_content)
+        extra_info, deselections = self.build_extra_info(queryset, ra, user, static_content)
         static_content.pop('new_state')  # Added this to extra with a dynamic url attached
 
         headers = {
@@ -44,7 +44,8 @@ class ReviewChangesChoiceField(ModelMultipleChoiceField):
             attrs={'tableclass': 'table'},
             headers=headers,
             top_header=top_header,
-            order=order
+            order=order,
+            deselections=deselections
         )
 
         super().__init__(queryset, **kwargs)
@@ -72,6 +73,7 @@ class ReviewChangesChoiceField(ModelMultipleChoiceField):
                     'state': status.state
                 }
 
+        deselections = False
         for concept in subclassed_queryset:
             url = reverse('aristotle:registrationHistory', kwargs={'iid': concept.id})
 
@@ -93,13 +95,14 @@ class ReviewChangesChoiceField(ModelMultipleChoiceField):
                 }
                 if state_info['state'] >= new_state_num:
                     innerdict['checked'] = False
+                    deselections = True
 
             innerdict['perm'] = perms.user_can_change_status(user, concept)
             innerdict['new_state'] =  {'url': url, 'text': new_state}
 
             extra_info[concept.id] = innerdict
 
-        return extra_info
+        return (extra_info, deselections)
 
 
 class MultipleEmailField(Field):

--- a/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/helpers/changestatus.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/helpers/changestatus.html
@@ -2,7 +2,7 @@
 <div class="changeStatusDiv">
     <span>
         <label for="id_registrationDate">{{ form.registrationDate.label }}</label>:
-        {{ form.registrationDate.errors }}
+        <span class="text-danger">{{ form.registrationDate.errors }}</span>
     </span>
     <span class="pull-right">
         {{ form.registrationDate }}
@@ -24,7 +24,7 @@
         <i class="fa fa-2x fa-question-circle"></i>
         </a>
         </label>
-        {{ form.cascadeRegistration.errors }}
+        <span class="text-danger">{{ form.cascadeRegistration.errors }}</span>
     </span>
     <span class="pull-right">
         {{ form.cascadeRegistration }}
@@ -34,11 +34,11 @@
     <div>
         <span>
             {{ form.state.label }}
-            {{ form.state.errors }}
+            <span class="text-danger">{{ form.state.errors }}</span>
         </span>
         <span>
             {{ form.registrationAuthorities.label }}
-            {{ form.registrationAuthorities.errors }}
+            <span class="text-danger">{{ form.registrationAuthorities.errors }}</span>
         </span>
     </div>
     <div>

--- a/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/widgets/table_checkbox_option.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/widgets/table_checkbox_option.html
@@ -1,2 +1,2 @@
-<td><input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} {% if not enabled %}disabled{% else %}checked{% endif %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+<td><input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} {% if not enabled %}disabled{% else %}{% if checked %}checked{% endif %}{% endif %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
 </td>{% if wrap_label %}<td><a {% if widget.value %}href="{% url 'aristotle:item' widget.value %}" target="_blank"{% endif %}>{{ widget.label }}</a></td>{% endif %}

--- a/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/widgets/table_checkbox_select.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/widgets/table_checkbox_select.html
@@ -10,7 +10,7 @@
   {% for group, options, index in widget.optgroups %}{% if group %}
   <td>{{ group }}<table{% if id %} id="{{ id }}_{{ index }}"{% endif %}>{% endif %}
     {% for option in options %}
-    <tr {% if not option.permission %}class="danger"{% endif %}>{% include option.template_name with widget=option enabled=option.permission %}
+    <tr {% if not option.permission %}class="danger"{% endif %}>{% include option.template_name with widget=option enabled=option.permission checked=option.checked %}
       {% for item in option.extra %}
       {% if item.url %}
       <td><a href={{ item.url }}>{{ item.text }}</a></td>

--- a/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/widgets/table_checkbox_select.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/widgets/table_checkbox_select.html
@@ -1,4 +1,5 @@
-{% if badperms %}<p>You do not have permission to update any items shown below in red</p>{% endif %}
+{% if badperms %}<div class="alert alert-warning" role="alert">You do not have permission to update the items shown below in red.</div>{% endif %}
+{% if deselections %}<div class="alert alert-warning" role="alert">Some items have been deselected automatically due to being registered in a higher state.</div>{% endif %}
 {% with id=widget.attrs.id %}<table{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.tableclass %} class="{{ widget.attrs.tableclass }}"{% endif %}>
   {% if top_header %}
     <tr>{% for header in top_header %}
@@ -13,7 +14,7 @@
     <tr {% if not option.permission %}class="danger"{% endif %}>{% include option.template_name with widget=option enabled=option.permission checked=option.checked %}
       {% for item in option.extra %}
       {% if item.url %}
-      <td><a href={{ item.url }}>{{ item.text }}</a></td>
+      <td><a href="{{ item.url }}">{{ item.text }}</a></td>
       {% else %}
       <td>{{ item }}</td>
       {% endif %}

--- a/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_bulk_actions.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_bulk_actions.py
@@ -45,6 +45,7 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
             reverse('aristotle:change_state_bulk_action'),
             postdata
         )
+        self.assertFalse(change_state_response.context['deselections'])
 
         self.assertEqual(change_state_response.status_code, 200)
         self.assertEqual(change_state_response.context['wizard']['steps'].step1, 2) # check we are now on second step
@@ -184,8 +185,8 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         self.assertTrue(self.item1.concept not in self.new_workgroup.items.all())
         self.assertTrue(self.item2.concept not in self.new_workgroup.items.all())
         self.assertTrue(self.item4.concept not in self.new_workgroup.items.all())
-
         response = self.client.post(
+
             reverse('aristotle:bulk_action'),
             {
                 'bulkaction': 'aristotle_mdr.forms.bulk_actions.ChangeWorkgroupForm',
@@ -384,6 +385,8 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         self.assertTrue(perms.user_can_change_status(self.registrar, self.item2))
 
         response = self.review_changes(items, STATES.standard)
+        self.assertTrue(response.context['deselections'])
+
         form = response.context['form']
         extra_info = form.fields['selected_list'].widget.extra_info
         self.assertTrue(extra_info[self.item1.id]['perm'])
@@ -418,6 +421,8 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         self.assertTrue(perms.user_can_change_status(self.registrar, self.item2))
 
         response = self.review_changes(items, STATES.standard)
+        self.assertTrue(response.context['deselections'])
+
         form = response.context['form']
         extra_info = form.fields['selected_list'].widget.extra_info
         self.assertTrue(extra_info[self.item1.id]['perm'])
@@ -435,6 +440,8 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         self.assertTrue(perms.user_can_change_status(self.registrar, self.item1))
 
         response = self.review_changes(items, STATES.standard)
+        self.assertFalse(response.context['deselections'])
+
         form = response.context['form']
         extra_info = form.fields['selected_list'].widget.extra_info
         self.assertTrue(extra_info[self.item1.id]['perm'])

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/views.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/views.py
@@ -406,7 +406,7 @@ class ReviewChangesView(SessionWizardView):
             state = cleaned_data['state']
             ra = cleaned_data['registrationAuthorities']
 
-            static_content = {'new_state': str(MDR.STATES[state]), 'new_reg_date': cleaned_data['registrationDate']}
+            static_content = {'new_state': state, 'new_reg_date': cleaned_data['registrationDate']}
             # Need to check wether cascaded was true here
 
             if cascade == 1:

--- a/python/aristotle-metadata-registry/aristotle_mdr/widgets/widgets.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/widgets/widgets.py
@@ -38,12 +38,13 @@ class RegistrationAuthoritySelect(forms.Select):
 
 class TableCheckboxSelect(CheckboxSelectMultiple):
 
-    def __init__(self, extra_info, static_info, headers, top_header, order, attrs=None, choices=(), **kwargs):
+    def __init__(self, extra_info, static_info, headers, top_header, order, attrs=None, choices=(), deselections=False, **kwargs):
         super().__init__(attrs, choices, **kwargs)
         self.extra_info = extra_info
         self.static_info = static_info
         self.order = order
         self.header_list = []
+        self.deselections = deselections
 
         for field in order:
             header = headers[field]
@@ -95,7 +96,8 @@ class TableCheckboxSelect(CheckboxSelectMultiple):
             'static_info': self.static_info,
             'headers': self.header_list,
             'badperms': self.badperms,
-            'top_header': self.top_header
+            'top_header': self.top_header,
+            'deselections': self.deselections
         })
 
         return context

--- a/python/aristotle-metadata-registry/aristotle_mdr/widgets/widgets.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/widgets/widgets.py
@@ -81,6 +81,7 @@ class TableCheckboxSelect(CheckboxSelectMultiple):
 
         option['extra'] = option_extra_list
         option['permission'] = option_extra['perm']
+        option['checked'] = option_extra['checked']
 
         if not option['permission']:
             self.badperms = True


### PR DESCRIPTION
Fixes issues: #

Sanity checks:
- [ ] Have tests been run locally?
- [ ] Does this change any javascript? If so, have you checked that the UI works as expected?
- [ ] If there are data model changes, are relevant data standards referenced - in code?
- [ ] If there are deviations from any specified standards, are the reasons for changes documented?
- [ ] If there are UI changes have you documented whats changed so the help documentation can be updated?
