### PR TITLE
Change how celery tasks in transactions are run

### DIFF
--- a/python/aristotle-bg-workers/aristotle_bg_workers/tasks.py
+++ b/python/aristotle-bg-workers/aristotle_bg_workers/tasks.py
@@ -1,12 +1,12 @@
-from typing import Optional, List, Tuple
-import datetime
-from io import StringIO
-
-from django.core.management import call_command
-from django.contrib.auth import get_user_model
-
 from celery import shared_task, Task
 from celery.utils.log import get_task_logger
+from io import StringIO
+from typing import Optional, List, Tuple
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.utils.module_loading import import_string
 
 from aristotle_mdr.utils.download import get_download_class
 from aristotle_mdr.models import _concept, RegistrationAuthority
@@ -55,7 +55,7 @@ def loadhelp_task(self, *args, **kwargs):
 
 @shared_task(name='fire_async_signal')
 def fire_async_signal(namespace, signal_name, message={}):
-    from django.utils.module_loading import import_string
+    """Runs the given function with the message as argument"""
     import_string("%s.%s" % (namespace, signal_name))(message)
 
 

--- a/python/aristotle-bg-workers/aristotle_bg_workers/tasks.py
+++ b/python/aristotle-bg-workers/aristotle_bg_workers/tasks.py
@@ -62,8 +62,12 @@ def fire_async_signal(namespace, signal_name, message={}):
 @shared_task(name='update_search_index')
 def update_search_index(action, sender, instance, **kwargs):
     from django.apps import apps
+    # Fetch sender model
     sender = apps.get_model(sender['app_label'], sender['model_name'])
-    instance = apps.get_model(instance['app_label'], instance['model_name']).objects.filter(pk=instance['pk']).first()
+    # Fetch instance (this will raise an exeption and fail the task if not found)
+    instance = apps.get_model(instance['app_label'], instance['model_name']).objects.get(pk=instance['pk'])
+
+    # Pass to haystack signal processor
     processor = apps.get_app_config('haystack').signal_processor
     if action == "save":
         logger.debug("UPDATING INDEX FOR {}".format(instance))

--- a/python/aristotle-bg-workers/aristotle_bg_workers/utils.py
+++ b/python/aristotle-bg-workers/aristotle_bg_workers/utils.py
@@ -1,0 +1,18 @@
+from typing import Iterable, Mapping
+from django.db import transaction
+from celery import Task
+
+from aristotle_bg_workers.celery import app
+
+
+def run_task_on_commit(task: Task, args: Iterable, kwargs: Mapping):
+    """Run a celery task after the next database commit (if we are in a transaction)"""
+    transaction.on_commit(lambda: task.delay(*args, **kwargs))
+
+
+def run_task_by_name_on_commit(task: str, args: Iterable, kwargs: Mapping):
+    """
+    Run a celery task by name after the next database commit (if we are in a transaction)
+    The function above is preffered, only use this one if you can't import the task
+    """
+    transaction.on_commit(lambda: app.send_task(task, args, kwargs))

--- a/python/aristotle-bg-workers/aristotle_bg_workers/utils.py
+++ b/python/aristotle-bg-workers/aristotle_bg_workers/utils.py
@@ -5,12 +5,12 @@ from celery import Task
 from aristotle_bg_workers.celery import app
 
 
-def run_task_on_commit(task: Task, args: Iterable, kwargs: Mapping):
+def run_task_on_commit(task: Task, args: Iterable = [], kwargs: Mapping = {}):
     """Run a celery task after the next database commit (if we are in a transaction)"""
     transaction.on_commit(lambda: task.delay(*args, **kwargs))
 
 
-def run_task_by_name_on_commit(task: str, args: Iterable, kwargs: Mapping):
+def run_task_by_name_on_commit(task: str, args: Iterable = [], kwargs: Mapping = {}):
     """
     Run a celery task by name after the next database commit (if we are in a transaction)
     The function above is preffered, only use this one if you can't import the task

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+from django.db.models import Model
 from django.apps import apps
 from django.conf import settings
 
@@ -32,7 +34,7 @@ def fire(signal_name, obj=None, namespace="aristotle_mdr.contrib.async_signals",
         import_string("%s.%s" % (namespace, signal_name))(message)
 
 
-def safe_object(message):
+def safe_object(message) -> Optional[Model]:
     __object__ = message['__object__']
     if __object__.get('object', None):
         instance = __object__['object']

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Mapping
 from django.db.models import Model
 from django.apps import apps
 from django.conf import settings
@@ -44,8 +44,16 @@ def safe_object(message) -> Optional[Model]:
     return instance
 
 
-def clean_signal(message):
-    message.pop('signal', None)
-    if message.get('changed_fields', False):
-        message['changed_fields'] = list(message['changed_fields'])
-    return message
+def clean_signal(kwargs: Mapping):
+    """Clean signal kwargs before serialization"""
+    # Remove these keys from mapping
+    keys_to_remove = ('signal', 'model', 'pk_set')
+    for key in keys_to_remove:
+        if key in kwargs:
+            del kwargs[key]
+
+    # Switch changed_fields to a list
+    if 'changed_fields' in kwargs:
+        kwargs['changed_fields'] = list(kwargs['changed_fields'])
+
+    return kwargs

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
@@ -3,8 +3,8 @@ from django.db.models import Model
 from django.apps import apps
 from django.conf import settings
 
-from aristotle_bg_workers.tasks import fire_async_signal
-from aristotle_bg_workers.utils import run_task_on_commit
+from aristotle_bg_workers.utils import run_task_by_name_on_commit
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ def fire(signal_name, obj=None, namespace="aristotle_mdr.contrib.async_signals",
         # Clean message of unwanted (and unserializable) content
         message = clean_signal(message)
         # Run the task after database commit
-        run_task_on_commit(fire_async_signal, args=[namespace, signal_name], kwargs={'message': message})
+        run_task_by_name_on_commit('fire_async_signal', args=[namespace, signal_name], kwargs={'message': message})
     else:
         message.update({'__object__': {'object': obj}})
         import_string("%s.%s" % (namespace, signal_name))(message)

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/async_signals/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Mapping
+from typing import Optional, Dict
 from django.db.models import Model
 from django.apps import apps
 from django.conf import settings
@@ -44,7 +44,7 @@ def safe_object(message) -> Optional[Model]:
     return model.objects.filter(pk=objdata['pk']).first()
 
 
-def clean_signal(kwargs: Mapping):
+def clean_signal(kwargs: Dict):
     """Clean signal kwargs before serialization"""
     # Remove these keys from mapping
     keys_to_remove = ('signal', 'model', 'pk_set')

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/reviews/tests.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/reviews/tests.py
@@ -489,6 +489,7 @@ class ReviewRequestSupersedesTestCase(utils.AristotleTestUtils, TestCase):
         ss.refresh_from_db()
         self.assertFalse(ss.proposed)
 
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_supersedes_status_applied(self):
         older = MDR.ObjectClass.objects.create(name='Old', definition='Very old')
         ss = self.create_ss_relation(older, self.item)

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/reviews/tests.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/reviews/tests.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.test import TestCase, tag
+from django.test import TestCase, tag, override_settings
 from django.core.cache import cache
 from unittest import skip
 from urllib.parse import urlencode

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/reviews/views.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/reviews/views.py
@@ -39,6 +39,7 @@ from aristotle_mdr.views.utils import (
 )
 
 from aristotle_bg_workers.tasks import register_items
+from aristotle_bg_workers.utils import run_task_on_commit
 
 from . import models, forms
 
@@ -267,15 +268,18 @@ class ReviewAcceptView(ReviewStatusChangeBase):
             regDate = timezone.now().date()
 
         # Set all old items to the Superseded status
-        register_items.delay(
-            old_items,
-            False,
-            MDR.STATES.superseded,
-            review.registration_authority_id,
-            self.request.user.id,
-            "",
-            (regDate.year, regDate.month, regDate.day),
-            False
+        run_task_on_commit(
+            register_items,
+            args=[
+                old_items,
+                False,
+                MDR.STATES.superseded,
+                review.registration_authority_id,
+                self.request.user.id,
+                "",
+                (regDate.year, regDate.month, regDate.day),
+                False
+            ]
         )
 
         # approve all proposed supersedes

--- a/python/aristotle-metadata-registry/aristotle_mdr/required_settings.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/required_settings.py
@@ -85,7 +85,11 @@ SILENCED_SYSTEM_CHECKS = [
 ALLOWED_HOSTS: list = []
 
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
+
+# Use asynchronous processing of signals
 ARISTOTLE_ASYNC_SIGNALS = os.getenv('ARISTOTLE_ASYNC_SIGNALS', False) == "True"
+# Always register items synchronously (without celery)
+ALWAYS_SYNC_REGISTER = os.getenv('ARISTOTLE_SYNC_REGISTER', False) == "True"
 
 INSTALLED_APPS = (
     'aristotle_bg_workers',

--- a/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_bulk_actions.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_bulk_actions.py
@@ -338,10 +338,12 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
             self.assertEqual(len(self.item2.current_statuses()), 0)
 
     @tag('changestatus')
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_bulk_status_change_on_permitted_items_direct(self):
         self.bulk_status_change_on_permitted_items(review_changes=False)
 
     @tag('changestatus')
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_bulk_status_change_on_permitted_items_with_review(self):
         self.bulk_status_change_on_permitted_items(review_changes=True)
 
@@ -435,6 +437,7 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         self.assertTrue(extra_info[self.item1.id]['checked'])
 
     @tag('changestatus')
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_bulk_status_change_cascade_common_child(self):
         # Test for changestatus with cascade  on 2 items with a common child
         self.login_superuser()
@@ -455,7 +458,7 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         self.assertEqual(change_state_get_response.context['form'].initial['items'], [str(a) for a in items])
 
         items_strings = [str(a) for a in items]
-        reg_date = datetime.date(2014,10,27)
+        reg_date = datetime.date(2014, 10, 27)
         new_state = self.ra.locked_state
 
         postdata = {
@@ -486,6 +489,7 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
                 'change_status_bulk_action_view-current_step': 'review_changes',
             }
         )
+        self.assertEqual(review_response.status_code, 302)
 
         for item in cascade_items:
 
@@ -494,6 +498,7 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
             self.assertTrue(item.current_statuses().first().registrationAuthority == self.ra)
 
     @tag('changestatus')
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_bulk_status_change_on_forbidden_items(self):
         self.login_registrar()
         self.make_review_request(self.item1, self.registrar)
@@ -582,7 +587,6 @@ class BulkWorkgroupActionsPage(BulkActionsTest, TestCase):
         self.assertTrue(self.item1.concept in self.new_workgroup.items.all())
         self.assertTrue(self.item2.concept in self.new_workgroup.items.all())
         self.assertTrue(self.item4.concept not in self.new_workgroup.items.all())
-
 
         self.logout()
         self.login_superuser()

--- a/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_html_pages.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_html_pages.py
@@ -1599,6 +1599,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
 
     @tag('changestatus')
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_registrar_can_change_status_with_cascade(self):
         if not hasattr(self,"run_cascade_tests"):
             return
@@ -1620,6 +1621,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
             self.assertTrue(sub_item.is_registered)
 
     @tag('changestatus')
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_registrar_can_change_status_with_cascade_bad_perms(self):
         if not hasattr(self,"run_cascade_tests"):
             return
@@ -1747,6 +1749,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
                     self.assertFalse(sub_item.is_registered)
 
     @tag('changestatus')
+    @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_registrar_can_change_status_with_review_cascade(self):
         self.registrar_can_change_status_with_review(cascade=True)
 

--- a/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_html_pages.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_html_pages.py
@@ -36,16 +36,16 @@ class AnonymousUserViewingThePages(TestCase):
 
     def test_notifications_for_anon_users(self):
         response = self.client.get(reverse('aristotle:home'))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         # Make sure notifications library isn't loaded for anon users as they'll never have notifications.
         self.assertNotContains(response, "notifications/notify.js")
         # At some stage this might need a better test to check the 500 page doesn't show... after notifications is fixed.
 
     def test_sitemaps(self):
         response = self.client.get("/sitemap.xml")
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         response = self.client.get("/sitemaps/sitemap_0.xml")
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
     def test_visible_item(self):
         steward_org = models.StewardOrganisation.objects.create(name="Test SO")
@@ -53,18 +53,18 @@ class AnonymousUserViewingThePages(TestCase):
         ra = models.RegistrationAuthority.objects.create(name="Test RA", stewardship_organisation=steward_org)
         item = models.ObjectClass.objects.create(name="Test OC", workgroup=wg)
         s = models.Status.objects.create(
-                concept=item,
-                registrationAuthority=ra,
-                registrationDate=timezone.now(),
-                state=ra.locked_state
-                )
+            concept=item,
+            registrationAuthority=ra,
+            registrationDate=timezone.now(),
+            state=ra.locked_state
+        )
         response = self.client.get(url_slugify_concept(item))
         # Anonymous users requesting a hidden page will be redirected to login
-        self.assertEqual(response.status_code,302)
+        self.assertEqual(response.status_code, 302)
         s.state = ra.public_state
         s.save()
         response = self.client.get(url_slugify_concept(item))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
 
 class LoggedInViewHTMLPages(utils.LoggedInViewPages, TestCase):
@@ -724,7 +724,6 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         )
         self.steward_org = models.StewardOrganisation.objects.create(name="Test SO")
 
-
     # ---- utils ----
 
     def loadHelp(self):
@@ -775,167 +774,168 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
     def test_su_can_view(self):
         self.login_superuser()
         response = self.client.get(self.get_page(self.item1))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         response = self.client.get(self.get_page(self.item2))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
         # Ensure short urls redirect properly
         response = self.client.get(reverse("aristotle:item_short", args=[self.item1.pk]))
-        self.assertEqual(response.status_code,302)
+        self.assertEqual(response.status_code, 302)
 
     def test_editor_can_view(self):
         self.login_editor()
         response = self.client.get(self.get_page(self.item1))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         response = self.client.get(self.get_page(self.item2))
-        self.assertEqual(response.status_code,403)
+        self.assertEqual(response.status_code, 403)
 
     def test_viewer_can_view(self):
         self.login_viewer()
         response = self.client.get(self.get_page(self.item1))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         response = self.client.get(self.get_page(self.item2))
-        self.assertEqual(response.status_code,403)
+        self.assertEqual(response.status_code, 403)
 
     def test_stubs_redirect_correctly(self):
         self.login_viewer()
-        response = self.client.get(reverse('aristotle:item',args=[self.item1.id]))
-        self.assertRedirects(response,url_slugify_concept(self.item1))
-        response = self.client.get(reverse('aristotle:item',args=[self.item1.id])+"/not-a-model/fake-name")
-        self.assertRedirects(response,url_slugify_concept(self.item1))
-        response = self.client.get(reverse('aristotle:item',args=[self.item1.id])+"/this-isnt-even-a-proper-stub")
-        self.assertRedirects(response,url_slugify_concept(self.item1))
+        response = self.client.get(reverse('aristotle:item', args=[self.item1.id]))
+        self.assertRedirects(response, url_slugify_concept(self.item1))
+        response = self.client.get(reverse('aristotle:item', args=[self.item1.id]) + "/not-a-model/fake-name")
+        self.assertRedirects(response, url_slugify_concept(self.item1))
+        response = self.client.get(reverse('aristotle:item', args=[self.item1.id]) + "/this-isnt-even-a-proper-stub")
+        self.assertRedirects(response, url_slugify_concept(self.item1))
 
     def test_uuids_redirect_correctly(self):
         self.login_viewer()
-        response = self.client.get(reverse('aristotle:item_uuid',args=[self.item1.id]))
-        self.assertRedirects(response,url_slugify_concept(self.item1))
+        response = self.client.get(reverse('aristotle:item_uuid', args=[self.item1.id]))
+        self.assertRedirects(response, url_slugify_concept(self.item1))
 
     def test_anon_cannot_view_edit_page(self):
         self.logout()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,302)
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item2.id]))
-        self.assertEqual(response.status_code,302)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 302)
+
     def test_viewer_cannot_view_edit_page(self):
         self.login_viewer()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,403)
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item2.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 403)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 403)
+
     def test_submitter_can_view_edit_page(self):
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         form = response.context['form']
         self.assertTrue('change_comments' in form.fields)
 
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item2.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 403)
 
     def test_regular_can_view_own_items_edit_page(self):
         self.login_regular_user()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,403)
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item2.id]))
-        self.assertEqual(response.status_code,403)
-        self.regular_item = self.itemType.objects.create(name="regular item",definition="my definition", submitter=self.regular,**self.defaults)
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.regular_item.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 403)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 403)
+        self.regular_item = self.itemType.objects.create(name="regular item", definition="my definition", submitter=self.regular, **self.defaults)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.regular_item.id]))
+        self.assertEqual(response.status_code, 200)
 
     def test_regular_can_save_via_edit_page(self):
         self.login_regular_user()
-        self.regular_item = self.itemType.objects.create(name="regular item",definition="my definition", submitter=self.regular,**self.defaults)
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.regular_item.id]))
-        self.assertEqual(response.status_code,200)
+        self.regular_item = self.itemType.objects.create(name="regular item", definition="my definition", submitter=self.regular, **self.defaults)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.regular_item.id]))
+        self.assertEqual(response.status_code, 200)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
         updated_item['name'] = updated_name
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.regular_item.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.regular_item.id]), updated_item)
         self.regular_item = self.itemType.objects.get(pk=self.regular_item.pk)
-        self.assertRedirects(response,url_slugify_concept(self.regular_item))
-        self.assertEqual(self.regular_item.name,updated_name)
+        self.assertRedirects(response, url_slugify_concept(self.regular_item))
+        self.assertEqual(self.regular_item.name, updated_name)
 
     def test_submitter_can_save_via_edit_page(self):
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
         updated_item['name'] = updated_name
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
-        self.assertRedirects(response,url_slugify_concept(self.item1))
-        self.assertEqual(self.item1.name,updated_name)
+        self.assertRedirects(response, url_slugify_concept(self.item1))
+        self.assertEqual(self.item1.name, updated_name)
 
     def test_submitter_can_save_item_with_no_workgroup_via_edit_page(self):
         self.login_editor()
-        self.item1 = self.itemType.objects.create(name="Test Item 1 (visible to tested viewers)",submitter=self.editor,definition="my definition",**self.defaults)
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        self.item1 = self.itemType.objects.create(name="Test Item 1 (visible to tested viewers)", submitter=self.editor, definition="my definition", **self.defaults)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
         updated_item['name'] = updated_name
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
-        self.assertRedirects(response,url_slugify_concept(self.item1))
-        self.assertEqual(self.item1.name,updated_name)
-        self.assertEqual(self.item1.workgroup,None)
+        self.assertRedirects(response, url_slugify_concept(self.item1))
+        self.assertEqual(self.item1.name, updated_name)
+        self.assertEqual(self.item1.workgroup, None)
 
     def test_submitter_can_save_via_edit_page_with_change_comment(self):
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
         updated_item['name'] = updated_name
         change_comment = "I changed this because I can"
         updated_item['change_comments'] = change_comment
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
 
-        self.assertRedirects(response,url_slugify_concept(self.item1))
-        self.assertEqual(self.item1.name,updated_name)
+        self.assertRedirects(response, url_slugify_concept(self.item1))
+        self.assertEqual(self.item1.name, updated_name)
 
-        response = self.client.get(reverse('aristotle:item_history',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:item_history', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, change_comment)
 
         self.logout()
-        response = self.client.get(reverse('aristotle:item_history',args=[self.item1.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:item_history', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 403)
         # self.assertNotContains(response, change_comment)
 
         models.Status.objects.create(
             concept=self.item1,
             registrationAuthority=self.ra,
-            registrationDate = datetime.date(2009,4,28),
-            state =  models.STATES.standard
-            )
+            registrationDate=datetime.date(2009, 4, 28),
+            state=models.STATES.standard
+        )
 
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
         self.assertTrue(self.item1._is_public)
         self.assertTrue(self.item1.can_view(None))
 
         response = self.client.get(self.get_page(self.item1))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
-        response = self.client.get(reverse('aristotle:item_history',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:item_history', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, change_comment)
-
 
     def test_submitter_can_save_via_edit_page_with_slots(self):
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(self.item1.slots.count(),0)
+        self.assertEqual(self.item1.slots.count(), 0)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
@@ -963,13 +963,13 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         updated_item.update(slot_formset_data)
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
 
-        self.assertRedirects(response,url_slugify_concept(self.item1))
-        self.assertEqual(self.item1.slots.count(),2)
+        self.assertRedirects(response, url_slugify_concept(self.item1))
+        self.assertEqual(self.item1.slots.count(), 2)
 
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
         self.assertContains(response, 'test slot value')
         self.assertContains(response, 'an even better test slot value')
 
@@ -979,14 +979,13 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.assertEqual(slots[1].name, 'more_extra')
         self.assertEqual(slots[1].order, 1)
 
-
     def test_submitter_can_save_via_edit_page_with_identifiers(self):
 
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(self.item1.slots.count(),0)
+        self.assertEqual(self.item1.slots.count(), 0)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
@@ -1017,13 +1016,13 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         updated_item.update(ident_formset_data)
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
 
-        self.assertRedirects(response,url_slugify_concept(self.item1))
-        self.assertEqual(self.item1.identifiers.count(),2)
+        self.assertRedirects(response, url_slugify_concept(self.item1))
+        self.assertEqual(self.item1.identifiers.count(), 2)
 
-        response = self.client.get(reverse('aristotle:item',args=[self.item1.id]), follow=True)
+        response = self.client.get(reverse('aristotle:item', args=[self.item1.id]), follow=True)
         self.assertContains(response, 'pre</a>/YE/1')
         self.assertContains(response, 'pre</a>/RE/1')
 
@@ -1037,19 +1036,19 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         self.login_editor()
         modified = self.item1.modified
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         # fake that we fetched the page seconds before modification
-        updated_item = utils.model_to_dict_with_change_time(response.context['item'],fetch_time=modified-datetime.timedelta(seconds=5))
+        updated_item = utils.model_to_dict_with_change_time(response.context['item'], fetch_time=modified - datetime.timedelta(seconds=5))
         updated_name = updated_item['name'] + " updated!"
         updated_item['name'] = updated_name
         change_comment = "I changed this because I can"
         updated_item['change_comments'] = change_comment
         time_before_response = timezone.now()
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
 
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         form = response.context['form']
         self.assertTrue(form.errors['last_fetched'][0] == CheckIfModifiedMixin.modified_since_form_fetched_error)
 
@@ -1058,15 +1057,14 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         # With the new last_fetched we can submit ok!
         updated_item['last_fetched'] = form.fields['last_fetched'].initial
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,302)
-
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 302)
 
         updated_item.pop('last_fetched')
         time_before_response = timezone.now()
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
 
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         form = response.context['form']
         self.assertTrue(form.errors['last_fetched'][0] == CheckIfModifiedMixin.modified_since_field_missing)
         # When sending a response with no last_fetch, the new one should come back right
@@ -1074,8 +1072,8 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         # With the new last_fetched we can submit ok!
         updated_item['last_fetched'] = form.fields['last_fetched'].initial
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,302)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 302)
 
     # Test if workgroup-moving settings work
 
@@ -1086,33 +1084,33 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.wg_other.giveRoleToUser('submitter', self.editor)
 
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
 
         updated_item['workgroup'] = str(self.wg_other.pk)
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
 
         form = response.context['form']
 
         self.assertTrue('workgroup' in form.errors.keys())
-        self.assertTrue(len(form.errors['workgroup'])==1)
+        self.assertTrue(len(form.errors['workgroup']) == 1)
 
         # Submitter is logged in, tries to move item - fails because
-        self.assertFalse(perms.user_can_remove_from_workgroup(self.editor,self.item1.workgroup))
+        self.assertFalse(perms.user_can_remove_from_workgroup(self.editor, self.item1.workgroup))
         self.assertTrue(form.errors['workgroup'][0] == WorkgroupVerificationMixin.cant_move_from_permission_error)
 
         updated_item['workgroup'] = str(self.wg2.pk)
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
 
         form = response.context['form']
 
         self.assertTrue('workgroup' in form.errors.keys())
-        self.assertTrue(len(form.errors['workgroup'])==1)
+        self.assertTrue(len(form.errors['workgroup']) == 1)
 
         self.assertTrue('Select a valid choice.' in form.errors['workgroup'][0])
 
@@ -1122,13 +1120,13 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.wg_other = models.Workgroup.objects.create(name="Test WG to move to", stewardship_organisation=self.steward_org)
 
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_item['workgroup'] = str(self.wg_other.pk)
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
 
         form = response.context['form']
 
@@ -1136,17 +1134,16 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         self.wg_other.giveRoleToUser('submitter', self.editor)
 
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
 
-        self.assertEqual(response.status_code,302)
+        self.assertEqual(response.status_code, 302)
         updated_item['workgroup'] = str(self.wg2.pk)
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
 
         self.assertTrue('Select a valid choice.' in form.errors['workgroup'][0])
-
 
     @override_settings(ARISTOTLE_SETTINGS=dict(settings.ARISTOTLE_SETTINGS, WORKGROUP_CHANGES=['admin']))
     def test_admin_can_change_workgroup_via_edit_page(self):
@@ -1154,19 +1151,18 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.wg_other = models.Workgroup.objects.create(name="Test WG to move to", stewardship_organisation=self.steward_org)
 
         self.login_superuser()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         updated_item = utils.model_to_dict_with_change_time(self.item1)
         updated_item['workgroup'] = str(self.wg_other.pk)
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,302)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 302)
 
         updated_item = utils.model_to_dict_with_change_time(self.item1)
         updated_item['workgroup'] = str(self.wg2.pk)
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,302)
-
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 302)
 
     @override_settings(ARISTOTLE_SETTINGS=dict(settings.ARISTOTLE_SETTINGS, WORKGROUP_CHANGES=['manager']))
     def test_manager_of_two_workgroups_can_change_workgroup_via_edit_page(self):
@@ -1175,12 +1171,12 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.wg_other.giveRoleToUser('submitter', self.editor)
 
         self.login_editor()
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_item['workgroup'] = str(self.wg_other.pk)
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
 
         form = response.context['form']
         # Submitter can't move because they aren't a manager of any workgroups.
@@ -1188,8 +1184,8 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         self.wg1.giveRoleToUser('manager', self.editor)
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
 
         form = response.context['form']
         # Submitter can't move because they aren't a manager of the workgroup the item is in.
@@ -1197,72 +1193,72 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         self.login_manager()
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
         form = response.context['form']
 
         self.assertTrue('Select a valid choice.' in form.errors['workgroup'][0])
 
         self.wg_other.giveRoleToUser('manager', self.manager)
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,302)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 302)
 
         updated_item['workgroup'] = str(self.wg2.pk)
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
+        self.assertEqual(response.status_code, 200)
 
         self.assertTrue('Select a valid choice.' in form.errors['workgroup'][0])
 
     @tag('clone_item')
     def test_anon_cannot_view_clone_page(self):
         self.logout()
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,302)
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item2.id]))
-        self.assertEqual(response.status_code,302)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 302)
 
     @tag('clone_item')
     def test_viewer_can_view_clone_page(self):
         self.login_viewer()
         # Viewer can clone an item they can see
         self.assertTrue(perms.user_can_view(self.viewer, self.item1))
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         # Viewer can't clone an item they can't see
         self.assertFalse(perms.user_can_view(self.viewer, self.item2))
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item2.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 403)
 
     @tag('clone_item')
     def test_submitter_can_view_clone_page(self):
         self.login_editor()
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item2.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 403)
 
     @tag('clone_item')
     def test_submitter_can_save_via_clone_page(self):
         self.login_editor()
         import time
-        time.sleep(2) # delays so there is a definite time difference between the first item and the clone on very fast test machines
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
-        updated_item = self.get_updated_data_for_clone(response) 
+        time.sleep(2)  # delays so there is a definite time difference between the first item and the clone on very fast test machines
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
+        updated_item = self.get_updated_data_for_clone(response)
         updated_name = updated_item['name'] + " cloned!"
         updated_item['name'] = updated_name
-        response = self.client.post(reverse('aristotle:clone_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:clone_item', args=[self.item1.id]), updated_item)
         # most_recent = self.itemType.objects.order_by('-created').first()
         most_recent = response.context[-1]['object']  # Get the item back to check
         self.assertTrue(perms.user_can_view(self.editor, most_recent))
 
-        self.assertRedirects(response,url_slugify_concept(most_recent))
-        self.assertEqual(most_recent.name,updated_name)
+        self.assertRedirects(response, url_slugify_concept(most_recent))
+        self.assertEqual(most_recent.name, updated_name)
 
         # Make sure the right item was save and our original hasn't been altered.
-        self.item1 = self.itemType.objects.get(id=self.item1.id) # Stupid cache
+        self.item1 = self.itemType.objects.get(id=self.item1.id)  # Stupid cache
         self.assertTrue('cloned' not in self.item1.name)
 
     @tag('clone_item')
@@ -1270,27 +1266,27 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.login_editor()
         # import time
         # time.sleep(2) # delays so there is a definite time difference between the first item and the clone on very fast test machines
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         # updated_item = utils.model_to_dict(response.context['item'])
-        updated_item = self.get_updated_data_for_clone(response) 
+        updated_item = self.get_updated_data_for_clone(response)
         updated_name = "CLONE" + updated_item['name'] + " cloned with no WG!"
         updated_item['name'] = updated_name
-        updated_item['workgroup'] = '' # no workgroup this time
-        response = self.client.post(reverse('aristotle:clone_item',args=[self.item1.id]), updated_item)
+        updated_item['workgroup'] = ''  # no workgroup this time
+        response = self.client.post(reverse('aristotle:clone_item', args=[self.item1.id]), updated_item)
 
-        self.assertTrue(response.status_code == 302) # make sure its saved ok
+        self.assertTrue(response.status_code == 302)  # make sure its saved ok
         most_recent = response.context[-1]['object']  # Get the item back to check
 
         self.assertTrue('cloned with no WG' in most_recent.name)
         self.assertTrue(most_recent.workgroup == None)
         self.assertTrue(perms.user_can_view(self.editor, most_recent))
 
-        self.assertRedirects(response,url_slugify_concept(most_recent))
-        self.assertEqual(most_recent.name,updated_name)
+        self.assertRedirects(response, url_slugify_concept(most_recent))
+        self.assertEqual(most_recent.name, updated_name)
 
         # Make sure the right item was saved and our original hasn't been altered.
-        self.item1 = self.itemType.objects.get(id=self.item1.id) # Stupid cache
+        self.item1 = self.itemType.objects.get(id=self.item1.id)  # Stupid cache
         self.assertTrue('cloned with no WG' not in self.item1.name)
 
     def get_updated_data_for_clone(self, response):
@@ -1322,16 +1318,16 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
                 # check that a formset with the correct prefix was rendered
                 self.assertIsNotNone(current_formset)
 
-                num_vals = getattr(self.item1,value_type).all().count()
-                ordering_field = getattr(self.item1,value_type).model.ordering_field
+                num_vals = getattr(self.item1, value_type).all().count()
+                ordering_field = getattr(self.item1, value_type).model.ordering_field
 
                 # check to make sure the classes with weak entities added them on setUp below
                 # self.assertGreater(num_vals, 0)
 
                 skipped_fields = ['id', 'ORDER', 'start_date', 'end_date', 'DELETE']
-                for i,v in enumerate(getattr(self.item1,value_type).all()):
-                    data.update({"%s-%d-id"%(pre,i): v.pk, "%s-%d-ORDER"%(pre,i) : getattr(v, ordering_field)})
-                    data.pop("%s-%d-id"%(pre,i))
+                for i, v in enumerate(getattr(self.item1, value_type).all()):
+                    data.update({"%s-%d-id" % (pre, i): v.pk, "%s-%d-ORDER" % (pre, i): getattr(v, ordering_field)})
+                    data.pop("%s-%d-id" % (pre, i))
                     for field in current_formset[0].fields:
                         if hasattr(v, field) and field not in skipped_fields:
                             value = getattr(v, field)
@@ -1344,55 +1340,54 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
                                         updating_field = field
 
                                 if field == updating_field:
-                                    data.update({"%s-%d-%s"%(pre,i,field) : value + ' -updated'})
+                                    data.update({"%s-%d-%s" % (pre, i, field): value + ' -updated'})
                                 else:
                                     added_value = value
                                     if field in default_fields:
-                                        data.update({"%s-%d-%s"%(pre,i,field) : default_fields[field]})
+                                        data.update({"%s-%d-%s" % (pre, i, field): default_fields[field]})
                                         added_value = default_fields[field]
                                     else:
-                                        data.update({"%s-%d-%s"%(pre,i,field) : value})
+                                        data.update({"%s-%d-%s" % (pre, i, field): value})
                                     if (i == num_vals - 1):
                                         # add a copy
-                                        data.update({"%s-%d-%s"%(pre,i+1,field) : added_value})
-                    data.pop("%s-%d-id"%(pre,i), None)
+                                        data.update({"%s-%d-%s" % (pre, i + 1, field): added_value})
+                    data.pop("%s-%d-id" % (pre, i), None)
 
                 data.update({
-                    "%s-TOTAL_FORMS"%pre:num_vals, "%s-INITIAL_FORMS"%0: num_vals, "%s-MAX_NUM_FORMS"%pre:1000,
-                    })
+                    "%s-TOTAL_FORMS" % pre: num_vals, "%s-INITIAL_FORMS" % 0: num_vals, "%s-MAX_NUM_FORMS" % pre: 1000,
+                })
             # import pdb; pdb.set_trace()
             return data
-
 
     def test_help_page_exists(self):
         self.logout()
         self.loadHelp()
         response = self.client.get(
-            reverse('aristotle_help:concept_help',args=[self.itemType._meta.app_label,self.itemType._meta.model_name])
+            reverse('aristotle_help:concept_help', args=[self.itemType._meta.app_label, self.itemType._meta.model_name])
         )
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
     def test_viewer_can_view_registration_history(self):
         self.login_viewer()
-        response = self.client.get(reverse('aristotle:registrationHistory',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
-        response = self.client.get(reverse('aristotle:registrationHistory',args=[self.item2.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:registrationHistory', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('aristotle:registrationHistory', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 403)
 
     def test_anon_cannot_view_registration_history(self):
         self.logout()
-        response = self.client.get(reverse('aristotle:registrationHistory',args=[self.item1.id]))
-        self.assertEqual(response.status_code,302)
-        response = self.client.get(reverse('aristotle:registrationHistory',args=[self.item2.id]))
-        self.assertEqual(response.status_code,302)
+        response = self.client.get(reverse('aristotle:registrationHistory', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get(reverse('aristotle:registrationHistory', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 302)
 
     def test_viewer_can_view_item_history(self):
         # Workgroup members can see the edit history of items
         self.login_viewer()
-        response = self.client.get(reverse('aristotle:item_history',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
-        response = self.client.get(reverse('aristotle:item_history',args=[self.item2.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:item_history', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('aristotle:item_history', args=[self.item2.id]))
+        self.assertEqual(response.status_code, 403)
 
         # # Viewers shouldn't even have the link to history on items they arent in the workgroup for
         # This check makes no sense - a user can't see the page to begin with.
@@ -1402,14 +1397,13 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         # Viewers will even have the link to history on items they are in the workgroup for
         response = self.client.get(self.item1.get_absolute_url())
-        self.assertContains(response, reverse('aristotle:item_history',args=[self.item1.id]))
+        self.assertContains(response, reverse('aristotle:item_history', args=[self.item1.id]))
 
     def test_editor_can_view_item_history__and__compare(self):
         self.login_editor()
 
         #from reversion import revisions as reversion
         import reversion
-
 
         # Creat a revision
         with reversion.revisions.create_revision():
@@ -1432,26 +1426,26 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         from reversion.models import Version
         revisions = Version.objects.get_for_object(self.item1)
 
-        response = self.client.get(reverse('aristotle:item_history',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:item_history', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         response = self.client.get(
-            reverse('aristotle:item_history',args=[self.item1.id]),
-            {'version_id1' : revisions.first().pk,
-            'version_id2' : revisions.last().pk
-            }
+            reverse('aristotle:item_history', args=[self.item1.id]),
+            {'version_id1': revisions.first().pk,
+             'version_id2': revisions.last().pk
+             }
         )
 
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "change 2")
         self.assertContains(response, 'statuses')
 
-        self.item1 = self.itemType.objects.get(pk=self.item1.pk) #decache
+        self.item1 = self.itemType.objects.get(pk=self.item1.pk)  # decache
         self.assertTrue(self.item1.name == "change 2")
         for s in self.item1.statuses.all():
             self.assertContains(
                 response,
-                '%s is %s'%(self.item1.name,s.get_state_display())
+                '%s is %s' % (self.item1.name, s.get_state_display())
             )
 
     def test_editor_can_revert_item_and_status_goes_back_too(self):
@@ -1465,8 +1459,8 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         original_name = self.item1.name
 
         # REVISION 1
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
@@ -1475,9 +1469,9 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         updated_item['change_comments'] = change_comment
 
         # REVISION 2
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
-        self.assertEqual(self.item1.name,updated_name)
+        self.assertEqual(self.item1.name, updated_name)
 
         self.make_review_request(self.item1, self.registrar)
 
@@ -1486,14 +1480,14 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
             state=models.STATES.incomplete,
             user=self.registrar
         )
-        self.item1 = self.itemType.objects.get(pk=self.item1.pk) #decache
+        self.item1 = self.itemType.objects.get(pk=self.item1.pk)  # decache
 
         self.assertTrue(self.item1.statuses.all().count() == 1)
         self.assertTrue(self.item1.statuses.first().state == models.STATES.incomplete)
 
         # REVISION 3
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name_again = updated_item['name'] + " updated!"
         updated_item['name'] = updated_name_again
@@ -1501,13 +1495,13 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         updated_item['change_comments'] = change_comment
 
         # REVISION 4
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.item1.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.item1.id]), updated_item)
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
-        self.assertEqual(self.item1.name,updated_name_again)
+        self.assertEqual(self.item1.name, updated_name_again)
 
         # REVISION 5
-        self.ra.register(self.item1,models.STATES.candidate,self.registrar)
-        self.item1 = self.itemType.objects.get(pk=self.item1.pk) #decache
+        self.ra.register(self.item1, models.STATES.candidate, self.registrar)
+        self.item1 = self.itemType.objects.get(pk=self.item1.pk)  # decache
         self.assertTrue(self.item1.statuses.count() == 2)
         self.assertTrue(self.item1.statuses.last().state == models.STATES.candidate)
 
@@ -1518,28 +1512,27 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
                 content_type_id=ct.id
             ).order_by('revision__date_created')
         )
-        versions[2].revision.revert(delete=True) # The version that has the first status changes
+        versions[2].revision.revert(delete=True)  # The version that has the first status changes
 
-        self.item1 = self.itemType.objects.get(pk=self.item1.pk) #decache
+        self.item1 = self.itemType.objects.get(pk=self.item1.pk)  # decache
 
         self.assertTrue(self.item1.statuses.count() == 1)
         self.assertTrue(self.item1.statuses.first().state == models.STATES.incomplete)
-        self.assertEqual(self.item1.name,updated_name)
+        self.assertEqual(self.item1.name, updated_name)
 
         # Go back to the initial revision
         versions[0].revision.revert(delete=True)
-        self.item1 = self.itemType.objects.get(pk=self.item1.pk) #decache
+        self.item1 = self.itemType.objects.get(pk=self.item1.pk)  # decache
         self.assertTrue(self.item1.statuses.count() == 0)
-        self.assertEqual(self.item1.name,original_name)
+        self.assertEqual(self.item1.name, original_name)
 
-
-        versions[4].revision.revert(delete=True) # Back to the latest version
-        self.item1 = self.itemType.objects.get(pk=self.item1.pk) #decache
+        versions[4].revision.revert(delete=True)  # Back to the latest version
+        self.item1 = self.itemType.objects.get(pk=self.item1.pk)  # decache
 
         self.assertTrue(self.item1.statuses.count() == 2)
         self.assertTrue(self.item1.statuses.order_by('state')[0].state == models.STATES.incomplete)
         self.assertTrue(self.item1.statuses.order_by('state')[1].state == models.STATES.candidate)
-        self.assertEqual(self.item1.name,updated_name_again)
+        self.assertEqual(self.item1.name, updated_name_again)
 
     @tag('changestatus')
     def test_registrar_can_change_status(self):
@@ -1547,25 +1540,25 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
         self.make_review_request(self.item1, self.registrar)
 
-        response = self.client.get(reverse('aristotle:changeStatus',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:changeStatus', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(self.item1.statuses.count(),0)
+        self.assertEqual(self.item1.statuses.count(), 0)
         response = self.client.post(
-            reverse('aristotle:changeStatus',args=[self.item1.id]),
+            reverse('aristotle:changeStatus', args=[self.item1.id]),
             {
                 'change_status-registrationAuthorities': [str(self.ra.id)],
                 'change_status-state': self.ra.public_state,
                 'change_status-changeDetails': "testing",
-                'change_status-cascadeRegistration': 0, # no
+                'change_status-cascadeRegistration': 0,  # no
                 'submit_skip': 'value',
                 'change_status_view-current_step': 'change_status',
             }
         )
-        self.assertRedirects(response,url_slugify_concept(self.item1))
+        self.assertRedirects(response, url_slugify_concept(self.item1))
 
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
-        self.assertEqual(self.item1.statuses.count(),1)
+        self.assertEqual(self.item1.statuses.count(), 1)
         self.assertTrue(self.item1.is_registered)
         self.assertTrue(self.item1.is_public())
 
@@ -1579,17 +1572,17 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.ra.active = 1
         self.ra.save()
 
-        response = self.client.get(reverse('aristotle:changeStatus',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:changeStatus', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         self.assertFalse(self.ra in response.context['form'].fields['registrationAuthorities'].queryset)
 
         response = self.client.post(
-            reverse('aristotle:changeStatus',args=[self.item1.id]),
+            reverse('aristotle:changeStatus', args=[self.item1.id]),
             {
                 'change_status-registrationAuthorities': [str(self.ra.id)],
                 'change_status-state': self.ra.public_state,
                 'change_status-changeDetails': "testing",
-                'change_status-cascadeRegistration': 0, # no
+                'change_status-cascadeRegistration': 0,  # no
                 'submit_skip': 'value',
                 'change_status_view-current_step': 'change_status',
             }
@@ -1597,11 +1590,10 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('registrationAuthorities' in response.context['form'].errors)
 
-
     @tag('changestatus')
     @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_registrar_can_change_status_with_cascade(self):
-        if not hasattr(self,"run_cascade_tests"):
+        if not hasattr(self, "run_cascade_tests"):
             return
         self.login_registrar()
 
@@ -1614,7 +1606,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.change_status(self.item1, self.registrar, self.ra, cascade=True)
 
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
-        self.assertEqual(self.item1.statuses.count(),1)
+        self.assertEqual(self.item1.statuses.count(), 1)
         self.assertTrue(self.item1.is_registered)
         self.assertTrue(self.item1.is_public())
         for sub_item in self.item1.registry_cascade_items:
@@ -1623,14 +1615,14 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
     @tag('changestatus')
     @override_settings(ALWAYS_SYNC_REGISTER=True)
     def test_registrar_can_change_status_with_cascade_bad_perms(self):
-        if not hasattr(self,"run_cascade_tests"):
+        if not hasattr(self, "run_cascade_tests"):
             return
         self.login_registrar()
 
         self.change_status(self.item1, self.registrar, self.ra, cascade=True)
 
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
-        self.assertEqual(self.item1.statuses.count(),1)
+        self.assertEqual(self.item1.statuses.count(), 1)
         self.assertTrue(self.item1.is_registered)
         self.assertTrue(self.item1.is_public())
         for sub_item in self.item1.registry_cascade_items:
@@ -1640,26 +1632,26 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
     def test_registrar_cannot_use_faulty_statuses(self):
         self.login_registrar()
 
-        self.assertFalse(perms.user_can_view(self.registrar,self.item1))
+        self.assertFalse(perms.user_can_view(self.registrar, self.item1))
         self.item1.save()
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
 
         self.make_review_request(self.item1, self.registrar)
 
-        self.assertTrue(perms.user_can_view(self.registrar,self.item1))
-        self.assertTrue(perms.user_can_add_status(self.registrar,self.item1))
+        self.assertTrue(perms.user_can_view(self.registrar, self.item1))
+        self.assertTrue(perms.user_can_add_status(self.registrar, self.item1))
 
-        response = self.client.get(reverse('aristotle:changeStatus',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:changeStatus', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(self.item1.statuses.count(),0)
+        self.assertEqual(self.item1.statuses.count(), 0)
         response = self.client.post(
             reverse('aristotle:changeStatus', args=[self.item1.id]),
             {
                 'change_status-registrationAuthorities': [str(self.ra.id)],
-                'change_status-state': "Not a number", # obviously wrong
+                'change_status-state': "Not a number",  # obviously wrong
                 'change_status-changeDetails': "testing",
-                'change_status-cascadeRegistration': 0, # no
+                'change_status-cascadeRegistration': 0,  # no
                 'submit_skip': 'value',
                 'change_status_view-current_step': 'change_status',
             }
@@ -1667,12 +1659,12 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         self.assertFormError(response, 'form', 'state', 'Select a valid choice. Not a number is not one of the available choices.')
 
         response = self.client.post(
-            reverse('aristotle:changeStatus',args=[self.item1.id]),
+            reverse('aristotle:changeStatus', args=[self.item1.id]),
             {
                 'change_status-registrationAuthorities': [str(self.ra.id)],
-                'change_status-state': "343434", # also wrong
+                'change_status-state': "343434",  # also wrong
                 'change_status-changeDetails': "testing",
-                'change_status-cascadeRegistration': 0, # no
+                'change_status-cascadeRegistration': 0,  # no
                 'submit_skip': 'value',
                 'change_status_view-current_step': 'change_status',
             }
@@ -1681,7 +1673,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
     def registrar_can_change_status_with_review(self, cascade):
         # If not running cascade tests return
-        if not hasattr(self,"run_cascade_tests") and cascade:
+        if not hasattr(self, "run_cascade_tests") and cascade:
             return
 
         self.login_registrar()
@@ -1694,8 +1686,8 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
             self.make_review_request(self.item1.registry_cascade_items[0], self.registrar)
 
         # Make sure registrar can view and change status of item
-        self.assertTrue(perms.user_can_view(self.registrar,self.item1))
-        self.assertTrue(perms.user_can_add_status(self.registrar,self.item1))
+        self.assertTrue(perms.user_can_view(self.registrar, self.item1))
+        self.assertTrue(perms.user_can_add_status(self.registrar, self.item1))
 
         # Check item is not registered
         self.assertFalse(self.item1.is_registered)
@@ -1706,7 +1698,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
             cascade_post = 0
 
         response = self.client.post(
-            reverse('aristotle:changeStatus',args=[self.item1.id]),
+            reverse('aristotle:changeStatus', args=[self.item1.id]),
             {
                 'change_status-registrationAuthorities': [str(self.ra.id)],
                 'change_status-state': self.ra.public_state,
@@ -1718,7 +1710,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['wizard']['steps'].step1, 2) # check we are now on second setep
+        self.assertEqual(response.context['wizard']['steps'].step1, 2)  # check we are now on second setep
 
         # On second step, select items we want to change
         selected_for_change = [self.item1.id]
@@ -1728,16 +1720,16 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         selected_for_change_strings = [str(a) for a in selected_for_change]
 
         review_response = self.client.post(
-            reverse('aristotle:changeStatus',args=[self.item1.id]),
+            reverse('aristotle:changeStatus', args=[self.item1.id]),
             {
                 'review_changes-selected_list': selected_for_change_strings,
                 'change_status_view-current_step': 'review_changes',
             }
         )
-        self.assertRedirects(review_response,url_slugify_concept(self.item1))
+        self.assertRedirects(review_response, url_slugify_concept(self.item1))
 
         self.item1.refresh_from_db()
-        self.assertEqual(self.item1.statuses.count(),1)
+        self.assertEqual(self.item1.statuses.count(), 1)
         self.assertTrue(self.item1.is_registered)
         self.assertTrue(self.item1.is_public())
         if cascade:
@@ -1761,15 +1753,15 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
     def test_viewer_cannot_change_status(self):
         self.login_viewer()
 
-        response = self.client.get(reverse('aristotle:changeStatus',args=[self.item1.id]))
-        self.assertEqual(response.status_code,403)
+        response = self.client.get(reverse('aristotle:changeStatus', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 403)
 
     @tag('changestatus')
     def test_anon_cannot_change_status(self):
         self.logout()
 
-        response = self.client.get(reverse('aristotle:changeStatus',args=[self.item1.id]))
-        self.assertRedirects(response,reverse('friendly_login')+"?next="+reverse('aristotle:changeStatus', args=[self.item1.id]))
+        response = self.client.get(reverse('aristotle:changeStatus', args=[self.item1.id]))
+        self.assertRedirects(response, reverse('friendly_login') + "?next=" + reverse('aristotle:changeStatus', args=[self.item1.id]))
 
     @tag('changestatus')
     def test_cascade_action(self):
@@ -1777,12 +1769,12 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
         check_url = reverse('aristotle:check_cascaded_states', args=[self.item1.pk])
 
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,403)
+        self.assertEqual(response.status_code, 403)
 
         self.login_editor()
 
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,404)
+        self.assertEqual(response.status_code, 404)
 
     def test_weak_editing_in_advanced_editor_dynamic(self, updating_field=None, default_fields={}):
 
@@ -1790,7 +1782,7 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
             self.login_editor()
             value_url = 'aristotle:edit_item'
 
-            response = self.client.get(reverse(value_url,args=[self.item1.id]))
+            response = self.client.get(reverse(value_url, args=[self.item1.id]))
             self.assertEqual(response.status_code, 200)
 
             weak_formsets = response.context['weak_formsets']
@@ -1813,15 +1805,15 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
                 data = utils.model_to_dict_with_change_time(self.item1)
 
-                num_vals = getattr(self.item1,value_type).all().count()
-                ordering_field = getattr(self.item1,value_type).model.ordering_field
+                num_vals = getattr(self.item1, value_type).all().count()
+                ordering_field = getattr(self.item1, value_type).model.ordering_field
 
                 # check to make sure the classes with weak entities added them on setUp below
                 self.assertGreater(num_vals, 0)
 
                 skipped_fields = ['id', 'ORDER', 'start_date', 'end_date', 'DELETE']
-                for i,v in enumerate(getattr(self.item1,value_type).all()):
-                    data.update({"%s-%d-id"%(pre,i): v.pk, "%s-%d-ORDER"%(pre,i) : getattr(v, ordering_field)})
+                for i, v in enumerate(getattr(self.item1, value_type).all()):
+                    data.update({"%s-%d-id" % (pre, i): v.pk, "%s-%d-ORDER" % (pre, i): getattr(v, ordering_field)})
                     for field in current_formset[0].fields:
                         if hasattr(v, field) and field not in skipped_fields:
                             value = getattr(v, field)
@@ -1835,45 +1827,45 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
                                         updating_field = field
 
                                 if field == updating_field:
-                                    data.update({"%s-%d-%s"%(pre,i,field) : value + ' -updated'})
+                                    data.update({"%s-%d-%s" % (pre, i, field): value + ' -updated'})
                                 else:
                                     added_value = value
                                     if field in default_fields:
-                                        data.update({"%s-%d-%s"%(pre,i,field) : default_fields[field]})
+                                        data.update({"%s-%d-%s" % (pre, i, field): default_fields[field]})
                                         added_value = default_fields[field]
                                     else:
-                                        data.update({"%s-%d-%s"%(pre,i,field) : value})
+                                        data.update({"%s-%d-%s" % (pre, i, field): value})
                                     if (i == num_vals - 1):
                                         # add a copy
-                                        data.update({"%s-%d-%s"%(pre,i+1,field) : added_value})
+                                        data.update({"%s-%d-%s" % (pre, i + 1, field): added_value})
 
                 self.assertIsNotNone(updating_field)
                 # no string was found to update
                 # if this happends the test needs to be passed an updating_field or changed to support more than text updates
 
-                i=0
-                data.update({"%s-%d-DELETE"%(pre,i): 'checked', "%s-%d-%s"%(pre,i,updating_field) : getattr(v, updating_field)+" - deleted"}) # delete the last one.
+                i = 0
+                data.update({"%s-%d-DELETE" % (pre, i): 'checked', "%s-%d-%s" % (pre, i, updating_field): getattr(v, updating_field) + " - deleted"})  # delete the last one.
 
                 # add order and updating_value to newly added data
-                i=num_vals
-                data.update({"%s-%d-ORDER"%(pre,i) : i, "%s-%d-%s"%(pre,i,updating_field) : "new value -updated"})
+                i = num_vals
+                data.update({"%s-%d-ORDER" % (pre, i): i, "%s-%d-%s" % (pre, i, updating_field): "new value -updated"})
 
                 # add management form
                 data.update({
-                    "%s-TOTAL_FORMS"%pre:num_vals+1, "%s-INITIAL_FORMS"%pre: num_vals, "%s-MAX_NUM_FORMS"%pre:1000,
-                    })
+                    "%s-TOTAL_FORMS" % pre: num_vals + 1, "%s-INITIAL_FORMS" % pre: num_vals, "%s-MAX_NUM_FORMS" % pre: 1000,
+                })
 
-                response = self.client.post(reverse(value_url,args=[self.item1.id]), data)
+                response = self.client.post(reverse(value_url, args=[self.item1.id]), data)
 
                 self.item1 = self.itemType.objects.get(pk=self.item1.pk)
 
-                self.assertTrue(num_vals == getattr(self.item1,value_type).all().count())
+                self.assertTrue(num_vals == getattr(self.item1, value_type).all().count())
 
                 new_value_seen = False
-                for v in getattr(self.item1,value_type).all():
+                for v in getattr(self.item1, value_type).all():
                     value = getattr(v, updating_field)
-                    self.assertTrue('updated' in value) # This will fail if the item isn't updated
-                    self.assertFalse('deleted' in value) # make sure deleted value not present
+                    self.assertTrue('updated' in value)  # This will fail if the item isn't updated
+                    self.assertFalse('deleted' in value)  # make sure deleted value not present
                     if value == 'new value -updated':
                         new_value_seen = True
                 self.assertTrue(new_value_seen)
@@ -1930,34 +1922,34 @@ class LoggedInViewConceptPages(utils.AristotleTestUtils):
 
 
 class ObjectClassViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='objectClass'
-    itemType=models.ObjectClass
+    url_name = 'objectClass'
+    itemType = models.ObjectClass
 
 
 class PropertyViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='property'
-    itemType=models.Property
+    url_name = 'property'
+    itemType = models.Property
 
 
 class UnitOfMeasureViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='unitOfMeasure'
-    itemType=models.UnitOfMeasure
+    url_name = 'unitOfMeasure'
+    itemType = models.UnitOfMeasure
 
 
 class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='valueDomain'
-    itemType=models.ValueDomain
+    url_name = 'valueDomain'
+    itemType = models.ValueDomain
 
     def setUp(self):
         super().setUp()
 
         for i in range(4):
             models.PermissibleValue.objects.create(
-                value=i,meaning="test permissible meaning %d"%i,order=i,valueDomain=self.item1
+                value=i, meaning="test permissible meaning %d" % i, order=i, valueDomain=self.item1
             )
         for i in range(4):
             models.SupplementaryValue.objects.create(
-                value=i,meaning="test supplementary meaning %d"%i,order=i,valueDomain=self.item1
+                value=i, meaning="test supplementary meaning %d" % i, order=i, valueDomain=self.item1
             )
 
         # Data used to test value domain conceptual domain link
@@ -1991,54 +1983,53 @@ class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
     def test_weak_editing_in_advanced_editor_dynamic(self):
         super().test_weak_editing_in_advanced_editor_dynamic(updating_field='value')
 
-    def submitter_user_can_use_value_edit_page(self,value_type):
+    def submitter_user_can_use_value_edit_page(self, value_type):
         value_url = 'aristotle:edit_item'
 
         self.login_editor()
 
         data = utils.model_to_dict_with_change_time(self.item1)
-        num_vals = getattr(self.item1,value_type+"Values").count()
-        i=0
-        for i,v in enumerate(getattr(self.item1,value_type+"Values").all()):
+        num_vals = getattr(self.item1, value_type + "Values").count()
+        i = 0
+        for i, v in enumerate(getattr(self.item1, value_type + "Values").all()):
             data.update({
-                "%s_values-%d-valueDomain"%(value_type, i): self.item1.pk,
-                "%s_values-%d-id"%(value_type,i): v.pk,
-                "%s_values-%d-ORDER"%(value_type,i) : v.order,
-                "%s_values-%d-value"%(value_type,i) : v.value,
-                "%s_values-%d-meaning"%(value_type,i) : v.meaning+" -updated"
+                "%s_values-%d-valueDomain" % (value_type, i): self.item1.pk,
+                "%s_values-%d-id" % (value_type, i): v.pk,
+                "%s_values-%d-ORDER" % (value_type, i): v.order,
+                "%s_values-%d-value" % (value_type, i): v.value,
+                "%s_values-%d-meaning" % (value_type, i): v.meaning + " -updated"
             })
         data.update({
-            "%s_values-%d-DELETE"%(value_type,i): 'checked',
-            "%s_values-%d-meaning"%(value_type,i) : v.meaning+" - deleted",
-            "%s_values-%d-valueDomain"%(value_type, i): self.item1.pk,
-        }) # delete the last one.
+            "%s_values-%d-DELETE" % (value_type, i): 'checked',
+            "%s_values-%d-meaning" % (value_type, i): v.meaning + " - deleted",
+            "%s_values-%d-valueDomain" % (value_type, i): self.item1.pk,
+        })  # delete the last one.
         # now add a new one
-        i=i+1
+        i = i + 1
         data.update({
-            "%s_values-%d-ORDER"%(value_type,i) : i,
-            "%s_values-%d-value"%(value_type,i) : 100,
-            "%s_values-%d-meaning"%(value_type,i) : "new value (also an updated value)",
-            "%s_values-%d-valueDomain"%(value_type, i): self.item1.pk,
+            "%s_values-%d-ORDER" % (value_type, i): i,
+            "%s_values-%d-value" % (value_type, i): 100,
+            "%s_values-%d-meaning" % (value_type, i): "new value (also an updated value)",
+            "%s_values-%d-valueDomain" % (value_type, i): self.item1.pk,
         })
 
         data.update({
-            "%s_values-TOTAL_FORMS"%(value_type): i+1,
-            "%s_values-INITIAL_FORMS"%(value_type): num_vals,
-            "%s_values-MAX_NUM_FORMS"%(value_type):1000,
+            "%s_values-TOTAL_FORMS" % (value_type): i + 1,
+            "%s_values-INITIAL_FORMS" % (value_type): num_vals,
+            "%s_values-MAX_NUM_FORMS" % (value_type): 1000,
         })
 
-        response = self.client.post(reverse(value_url,args=[self.item1.id]),data)
+        response = self.client.post(reverse(value_url, args=[self.item1.id]), data)
         self.assertEqual(response.status_code, 302)
         self.item1 = models.ValueDomain.objects.get(pk=self.item1.pk)
 
-        self.assertEqual(num_vals, getattr(self.item1,value_type+"Values").count())
+        self.assertEqual(num_vals, getattr(self.item1, value_type + "Values").count())
         new_value_seen = False
-        for v in getattr(self.item1,value_type+"Values").all():
-            self.assertTrue('updated' in v.meaning) # This will fail if the deleted item isn't deleted
+        for v in getattr(self.item1, value_type + "Values").all():
+            self.assertTrue('updated' in v.meaning)  # This will fail if the deleted item isn't deleted
             if v.value == '100' and "new value" in v.meaning:
                 new_value_seen = True
         self.assertTrue(new_value_seen)
-
 
         # Item is now locked, submitter is no longer able to edit
         models.Status.objects.create(
@@ -2050,7 +2041,7 @@ class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
 
         self.item1 = models.ValueDomain.objects.get(pk=self.item1.pk)
         self.assertTrue(self.item1.is_locked())
-        self.assertFalse(perms.user_can_edit(self.editor,self.item1))
+        self.assertFalse(perms.user_can_edit(self.editor, self.item1))
 
     def test_submitter_can_use_permissible_value_edit_page(self):
         self.submitter_user_can_use_value_edit_page('permissible')
@@ -2064,49 +2055,49 @@ class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
     def test_submitter_user_doesnt_save_all_blank_supplementary_value_edit_page(self):
         self.submitter_user_doesnt_save_all_blank('supplementary')
 
-    def submitter_user_doesnt_save_all_blank(self,value_type):
+    def submitter_user_doesnt_save_all_blank(self, value_type):
         value_url = 'aristotle:edit_item'
 
         self.login_editor()
 
         data = utils.model_to_dict_with_change_time(self.item1)
-        num_vals = getattr(self.item1,value_type+"Values").count()
+        num_vals = getattr(self.item1, value_type + "Values").count()
 
-        i=0
-        for i,v in enumerate(getattr(self.item1,value_type+"Values").all()):
+        i = 0
+        for i, v in enumerate(getattr(self.item1, value_type + "Values").all()):
             data.update({
-                "%s_values-%d-valueDomain"%(value_type, i): self.item1.pk,
-                "%s_values-%d-id"%(value_type, i): v.pk,
-                "%s_values-%d-ORDER"%(value_type, i) : v.order,
-                "%s_values-%d-value"%(value_type, i) : v.value,
-                "%s_values-%d-meaning"%(value_type, i) : v.meaning+" -updated"
+                "%s_values-%d-valueDomain" % (value_type, i): self.item1.pk,
+                "%s_values-%d-id" % (value_type, i): v.pk,
+                "%s_values-%d-ORDER" % (value_type, i): v.order,
+                "%s_values-%d-value" % (value_type, i): v.value,
+                "%s_values-%d-meaning" % (value_type, i): v.meaning + " -updated"
             })
 
         # now add two new values that are all blank
-        i=i+1
-        data.update({"%s_values-%d-ORDER"%(value_type, i) : i, "%s_values-%d-value"%(value_type, i) : '', "%s_values-%d-meaning"%(value_type, i) : ""})
-        i=i+1
-        data.update({"%s_values-%d-ORDER"%(value_type, i) : i, "%s_values-%d-value"%(value_type, i) : '', "%s_values-%d-meaning"%(value_type, i) : ""})
+        i = i + 1
+        data.update({"%s_values-%d-ORDER" % (value_type, i): i, "%s_values-%d-value" % (value_type, i): '', "%s_values-%d-meaning" % (value_type, i): ""})
+        i = i + 1
+        data.update({"%s_values-%d-ORDER" % (value_type, i): i, "%s_values-%d-value" % (value_type, i): '', "%s_values-%d-meaning" % (value_type, i): ""})
 
         data.update({
-            "%s_values-TOTAL_FORMS"%(value_type): i+1,
-            "%s_values-INITIAL_FORMS"%(value_type): num_vals,
-            "%s_values-MAX_NUM_FORMS"%(value_type):1000,
+            "%s_values-TOTAL_FORMS" % (value_type): i + 1,
+            "%s_values-INITIAL_FORMS" % (value_type): num_vals,
+            "%s_values-MAX_NUM_FORMS" % (value_type): 1000,
         })
-        self.client.post(reverse(value_url,args=[self.item1.id]),data)
+        self.client.post(reverse(value_url, args=[self.item1.id]), data)
         self.item1 = models.ValueDomain.objects.get(pk=self.item1.pk)
 
-        self.assertTrue(num_vals == getattr(self.item1,value_type+"Values").count())
+        self.assertTrue(num_vals == getattr(self.item1, value_type + "Values").count())
 
     def test_values_shown_on_page(self):
         self.login_viewer()
 
         response = self.client.get(self.get_page(self.item1))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         for pv in self.item1.permissiblevalue_set.all():
-            self.assertContains(response,pv.meaning,1)
+            self.assertContains(response, pv.meaning, 1)
         for sv in self.item1.supplementaryvalue_set.all():
-            self.assertContains(response,sv.meaning,1)
+            self.assertContains(response, sv.meaning, 1)
 
     @skip('Not fixed yet')
     def test_conceptual_domain_selection(self):
@@ -2119,7 +2110,7 @@ class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
         # check queryset correctly filled from conceptual domain for item 2
         formset = response.context['weak_formsets'][0]['formset']
         form = formset.empty_form
-        
+
         self.assertFalse('meaning' in form.fields.keys())
         self.assertTrue('value_meaning' in form.fields.keys())
         queryset = form.fields['value_meaning'].queryset
@@ -2214,15 +2205,15 @@ class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
     def test_clone_vd_with_components(self):
         self.login_editor()
         old_name = self.item1.name
-        response = self.client.get(reverse('aristotle:clone_item',args=[self.item1.id]))
-        self.assertEqual(response.status_code,200)
+        response = self.client.get(reverse('aristotle:clone_item', args=[self.item1.id]))
+        self.assertEqual(response.status_code, 200)
         data = self.get_updated_data_for_clone(response)
         data.update({
             'name': 'Goodness (clone)',
             'definition': 'A measure of good'
         })
 
-        response = self.client.post(reverse('aristotle:clone_item',args=[self.item1.id]), data)
+        response = self.client.post(reverse('aristotle:clone_item', args=[self.item1.id]), data)
 
         clone = response.context[-1]['object']  # Get the item back to check
         self.item1 = models.ValueDomain.objects.get(pk=self.item1.pk)
@@ -2239,8 +2230,8 @@ class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
     def create_bulk_values(self, n: int, vd):
         pvs = []
         for i in range(n):
-            value='Value {}'.format(i),
-            meaning='Meaning {}'.format(i),
+            value = 'Value {}'.format(i),
+            meaning = 'Meaning {}'.format(i),
             pv = models.PermissibleValue(
                 valueDomain=vd,
                 value=value,
@@ -2339,8 +2330,8 @@ class ValueDomainViewPage(LoggedInViewConceptPages, TestCase):
 
 
 class ConceptualDomainViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='conceptualDomain'
-    itemType=models.ConceptualDomain
+    url_name = 'conceptualDomain'
+    itemType = models.ConceptualDomain
 
     def setUp(self):
         super().setUp()
@@ -2359,7 +2350,7 @@ class ConceptualDomainViewPage(LoggedInViewConceptPages, TestCase):
         self.login_editor()
 
         edit_url = 'aristotle:edit_item'
-        response = self.client.get(reverse(edit_url,args=[self.item1.id]))
+        response = self.client.get(reverse(edit_url, args=[self.item1.id]))
         self.assertEqual(response.status_code, 200)
 
         data = utils.model_to_dict_with_change_time(self.item1)
@@ -2370,7 +2361,7 @@ class ConceptualDomainViewPage(LoggedInViewConceptPages, TestCase):
             {'name': 'Test2', 'definition': 'test defn', 'start_date': '1999-01-01', 'end_date': '2090-01-01', 'ORDER': 1}
         ]
         data.update(self.get_formset_postdata(valuemeaning_formset_data, 'value_meaning', 0))
-        response = self.client.post(reverse(edit_url,args=[self.item1.id]), data)
+        response = self.client.post(reverse(edit_url, args=[self.item1.id]), data)
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.context['weak_formsets'][0]['formset'].errors[0], {'name': ['This field is required.']})
@@ -2378,8 +2369,8 @@ class ConceptualDomainViewPage(LoggedInViewConceptPages, TestCase):
 
 
 class DataElementConceptViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='dataElementConcept'
-    itemType=models.DataElementConcept
+    url_name = 'dataElementConcept'
+    itemType = models.DataElementConcept
     run_cascade_tests = True
 
     def setUp(self, *args, **kwargs):
@@ -2403,28 +2394,28 @@ class DataElementConceptViewPage(LoggedInViewConceptPages, TestCase):
 
         check_url = reverse('aristotle:generic_foreign_key_editor', args=[self.item1.pk, 'objectclassarino'])
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,404)
+        self.assertEqual(response.status_code, 404)
 
         check_url = reverse('aristotle:generic_foreign_key_editor', args=[self.item1.pk, 'objectclass'])
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,302)  # user must login too see
+        self.assertEqual(response.status_code, 302)  # user must login too see
 
-        response = self.client.post(check_url,{'objectClass':''})
-        self.assertEqual(response.status_code,302)
+        response = self.client.post(check_url, {'objectClass': ''})
+        self.assertEqual(response.status_code, 302)
         self.item1 = self.item1.__class__.objects.get(pk=self.item1.pk)
         self.assertTrue(self.item1.objectClass is not None)
 
         self.login_editor()
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
-        response = self.client.post(check_url,{'objectClass':''})
-        self.assertEqual(response.status_code,302)
+        response = self.client.post(check_url, {'objectClass': ''})
+        self.assertEqual(response.status_code, 302)
         self.item1 = self.item1.__class__.objects.get(pk=self.item1.pk)
         self.assertTrue(self.item1.objectClass is None)
 
-        response = self.client.post(check_url,{'objectClass':self.prop.pk})
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(check_url, {'objectClass': self.prop.pk})
+        self.assertEqual(response.status_code, 200)
         self.item1 = self.item1.__class__.objects.get(pk=self.item1.pk)
         self.assertTrue(self.item1.objectClass is None)
 
@@ -2432,22 +2423,21 @@ class DataElementConceptViewPage(LoggedInViewConceptPages, TestCase):
             name="editor can't see this",
             definition="my definition",
         )
-        response = self.client.post(check_url,{'objectClass':another_oc.pk})
-        self.assertEqual(response.status_code,200)
+        response = self.client.post(check_url, {'objectClass': another_oc.pk})
+        self.assertEqual(response.status_code, 200)
         self.item1 = self.item1.__class__.objects.get(pk=self.item1.pk)
         self.assertTrue(self.item1.objectClass is None)
 
-
-        response = self.client.post(check_url,{'objectClass':self.oc.pk})
-        self.assertEqual(response.status_code,302)
+        response = self.client.post(check_url, {'objectClass': self.oc.pk})
+        self.assertEqual(response.status_code, 302)
         self.item1 = self.item1.__class__.objects.get(pk=self.item1.pk)
         self.assertTrue(self.item1.objectClass == self.oc)
 
     def test_regular_cannot_save_a_property_they_cant_see_via_edit_page(self):
         self.login_regular_user()
-        self.regular_item = self.itemType.objects.create(name="regular item",definition="my definition", submitter=self.regular,**self.defaults)
-        response = self.client.get(reverse('aristotle:edit_item',args=[self.regular_item.id]))
-        self.assertEqual(response.status_code,200)
+        self.regular_item = self.itemType.objects.create(name="regular item", definition="my definition", submitter=self.regular, **self.defaults)
+        response = self.client.get(reverse('aristotle:edit_item', args=[self.regular_item.id]))
+        self.assertEqual(response.status_code, 200)
 
         updated_item = utils.model_to_dict_with_change_time(response.context['item'])
         updated_name = updated_item['name'] + " updated!"
@@ -2462,10 +2452,10 @@ class DataElementConceptViewPage(LoggedInViewConceptPages, TestCase):
         self.assertFalse(self.prop.can_view(self.regular))
         self.assertFalse(different_prop.can_view(self.regular))
 
-        response = self.client.post(reverse('aristotle:edit_item',args=[self.regular_item.id]), updated_item)
+        response = self.client.post(reverse('aristotle:edit_item', args=[self.regular_item.id]), updated_item)
         self.regular_item = self.itemType.objects.get(pk=self.regular_item.pk)
 
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         self.assertTrue('not one of the available choices' in response.context['form'].errors['property'][0])
         self.assertFalse(self.regular_item.name == updated_name)
         self.assertFalse(self.regular_item.property == self.prop)
@@ -2475,41 +2465,41 @@ class DataElementConceptViewPage(LoggedInViewConceptPages, TestCase):
         check_url = reverse('aristotle:check_cascaded_states', args=[self.item1.pk])
 
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,403)
+        self.assertEqual(response.status_code, 403)
 
         self.login_editor()
 
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.item1.objectClass.name)
         self.assertContains(response, self.item1.property.name)
 
         ra = models.RegistrationAuthority.objects.create(name="new RA", stewardship_organisation=self.steward_org)
         item = self.item1.property
         s = models.Status.objects.create(
-                concept=item,
-                registrationAuthority=ra,
-                registrationDate=timezone.now(),
-                state=ra.locked_state
-                )
+            concept=item,
+            registrationAuthority=ra,
+            registrationDate=timezone.now(),
+            state=ra.locked_state
+        )
         s = models.Status.objects.create(
-                concept=item,
-                registrationAuthority=self.ra,
-                registrationDate=timezone.now(),
-                state=ra.locked_state
-                )
+            concept=item,
+            registrationAuthority=self.ra,
+            registrationDate=timezone.now(),
+            state=ra.locked_state
+        )
         s = models.Status.objects.create(
-                concept=self.item1,
-                registrationAuthority=self.ra,
-                registrationDate=timezone.now(),
-                state=ra.public_state
-                )
+            concept=self.item1,
+            registrationAuthority=self.ra,
+            registrationDate=timezone.now(),
+            state=ra.public_state
+        )
 
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.item1.objectClass.name)
         self.assertContains(response, self.item1.property.name)
-        self.assertContains(response, 'fa-times') # The property has a different status
+        self.assertContains(response, 'fa-times')  # The property has a different status
 
     def test_user_can_not_see_sub_components_without_permission(self):
         self.prop.workgroup = self.wg2
@@ -2527,8 +2517,8 @@ class DataElementConceptViewPage(LoggedInViewConceptPages, TestCase):
 
 
 class DataElementViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='dataElement'
-    itemType=models.DataElement
+    url_name = 'dataElement'
+    itemType = models.DataElement
 
     def add_dec(self, wg):
         dec = models.DataElementConcept.objects.create(
@@ -2542,17 +2532,17 @@ class DataElementViewPage(LoggedInViewConceptPages, TestCase):
     def test_cascade_action(self):
         self.logout()
         check_url = reverse('aristotle:check_cascaded_states', args=[self.item1.pk])
-        self.dec1 = models.DataElementConcept.objects.create(name='DEC1 - visible',definition="my definition",workgroup=self.wg1)
+        self.dec1 = models.DataElementConcept.objects.create(name='DEC1 - visible', definition="my definition", workgroup=self.wg1)
         self.item1.dataElementConcept = self.dec1
         self.item1.save()
 
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,403)
+        self.assertEqual(response.status_code, 403)
 
         self.login_editor()
 
         response = self.client.get(check_url)
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
     @tag('version')
     def test_version_display_components(self):
@@ -2631,9 +2621,10 @@ class DataElementViewPage(LoggedInViewConceptPages, TestCase):
         self.assertFalse(components['Data Element Concept'].is_link, False)
         self.assertTrue(components['Data Element Concept'].value.startswith('Linked to object'))
 
+
 class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
-    url_name='dataelementderivation'
-    itemType=models.DataElementDerivation
+    url_name = 'dataelementderivation'
+    itemType = models.DataElementDerivation
 
     def test_weak_editing_in_advanced_editor_dynamic(self):
         self.item1 = self.create_linked_ded()
@@ -2642,9 +2633,9 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
 
     def create_linked_ded(self):
 
-        self.de1 = models.DataElement.objects.create(name='DE1 Name',definition="my definition",workgroup=self.wg1)
-        self.de2 = models.DataElement.objects.create(name='DE2 Name',definition="my definition",workgroup=self.wg1)
-        self.de3 = models.DataElement.objects.create(name='DE3 Name',definition="my definition",workgroup=self.wg1)
+        self.de1 = models.DataElement.objects.create(name='DE1 Name', definition="my definition", workgroup=self.wg1)
+        self.de2 = models.DataElement.objects.create(name='DE2 Name', definition="my definition", workgroup=self.wg1)
+        self.de3 = models.DataElement.objects.create(name='DE3 Name', definition="my definition", workgroup=self.wg1)
         self.ded = models.DataElementDerivation.objects.create(name='DED Name', definition='my definition', workgroup=self.wg1)
 
         ded_derives_1 = models.DedDerivesThrough.objects.create(data_element_derivation=self.ded, data_element=self.de1, order=0)
@@ -2658,9 +2649,9 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
         return self.ded
 
     def derivation_m2m_concepts_save(self, url, attr):
-        self.de1 = models.DataElement.objects.create(name='DE1 - visible',definition="my definition",workgroup=self.wg1)
-        self.de2 = models.DataElement.objects.create(name='DE2 - not visible',definition="my definition",workgroup=self.wg2)
-        self.oc1 = models.ObjectClass.objects.create(name='OC - visible but wrong',definition="my definition",workgroup=self.wg1)
+        self.de1 = models.DataElement.objects.create(name='DE1 - visible', definition="my definition", workgroup=self.wg1)
+        self.de2 = models.DataElement.objects.create(name='DE2 - not visible', definition="my definition", workgroup=self.wg2)
+        self.oc1 = models.ObjectClass.objects.create(name='OC - visible but wrong', definition="my definition", workgroup=self.wg1)
 
         self.login_editor()
 
@@ -2676,7 +2667,7 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
         response = self.client.get(
             reverse(url, args=[self.item1.pk])
         )
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
         postdata = management_form.copy()
         postdata['form-0-item_to_add'] = self.de2.pk
@@ -2689,7 +2680,7 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
         )
         self.item1 = self.itemType.objects.get(pk=self.item1.pk)
         self.assertTrue(self.de2 not in getattr(self.item1, attr).all())
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Select a valid choice')
 
         postdata = management_form.copy()
@@ -2706,7 +2697,7 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
         )
         self.assertTrue(self.de2 not in getattr(self.item1, attr).all())
         self.assertContains(response, 'Select a valid choice')
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
         # user can see OC1, but its the wrong type so expect failure
 
@@ -2724,7 +2715,7 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
         )
         self.assertTrue(self.de2 not in getattr(self.item1, attr).all())
         self.assertContains(response, 'Select a valid choice')
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
         postdata = management_form.copy()
         postdata['form-0-item_to_add'] = self.de1.pk
@@ -2735,14 +2726,14 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
             postdata
         )
         self.assertTrue(self.de1 in getattr(self.item1, attr).all())
-        self.assertEqual(response.status_code,302)
+        self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, self.item1.get_absolute_url())
 
     def derivation_m2m_formset(self, url, attr, prefix='form', item_add_field='item_to_add', add_itemdata=False, extra_postdata=None):
 
-        self.de1 = models.DataElement.objects.create(name='DE1 - visible',definition="my definition",workgroup=self.wg1)
-        self.de2 = models.DataElement.objects.create(name='DE2 - visible',definition="my definition",workgroup=self.wg1)
-        self.de3 = models.DataElement.objects.create(name='DE3 - visible',definition="my definition",workgroup=self.wg1)
+        self.de1 = models.DataElement.objects.create(name='DE1 - visible', definition="my definition", workgroup=self.wg1)
+        self.de2 = models.DataElement.objects.create(name='DE2 - visible', definition="my definition", workgroup=self.wg1)
+        self.de3 = models.DataElement.objects.create(name='DE3 - visible', definition="my definition", workgroup=self.wg1)
 
         self.login_editor()
 
@@ -2793,7 +2784,7 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
 
             self.assertEqual(len(formset_initial), 3)
             for data in formset_initial:
-                self.assertTrue(data['ORDER'] in [0,1,2])
+                self.assertTrue(data['ORDER'] in [0, 1, 2])
                 if data['ORDER'] == 0:
                     self.assertEqual(data['{}'.format(item_add_field)], self.de3)
                 elif data['ORDER'] == 1:
@@ -2811,7 +2802,6 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
         self.assertEqual(through_model.objects.get(order=0).data_element, self.de3)
         self.assertEqual(through_model.objects.get(order=1).data_element, self.de1)
         self.assertEqual(through_model.objects.get(order=2).data_element, self.de2)
-
 
         # Change order and delete
         postdata = management_form.copy()
@@ -2855,7 +2845,7 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
             # If m2m specific form
             self.assertEqual(len(formset_initial), 2)
             for data in formset_initial:
-                self.assertTrue(data['ORDER'] in [1,2])
+                self.assertTrue(data['ORDER'] in [1, 2])
                 if data['ORDER'] == 1:
                     self.assertEqual(data['{}'.format(item_add_field)], self.de2)
                 elif data['ORDER'] == 2:
@@ -2903,6 +2893,7 @@ class DataElementDerivationViewPage(LoggedInViewConceptPages, TestCase):
 
 class LoggedInViewManagedItemPages(utils.LoggedInViewPages):
     defaults = {}
+
     def setUp(self):
         super().setUp()
         self.item1 = self.itemType.objects.create(
@@ -2911,20 +2902,19 @@ class LoggedInViewManagedItemPages(utils.LoggedInViewPages):
             **self.defaults
         )
 
-
-    def get_page(self,item):
+    def get_page(self, item):
         return item.get_absolute_url()
 
     def test_help_page_exists(self):
         self.logout()
         #response = self.client.get(self.get_help_page())
-        #self.assertEqual(response.status_code,200)
+        # self.assertEqual(response.status_code,200)
 
     def test_item_page_exists(self):
         self.logout()
         self.login_superuser()
         response = self.client.get(self.get_page(self.item1))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)
 
     def test_item_page_viewable_when_published(self):
         self.logout()
@@ -2933,19 +2923,19 @@ class LoggedInViewManagedItemPages(utils.LoggedInViewPages):
 
         from aristotle_mdr.contrib.publishing import models
         from aristotle_mdr.constants import visibility_permission_choices
-    
+
         publication_details = models.PublicationRecord.objects.create(
             content_type=ContentType.objects.get_for_model(self.item1),
             object_id=self.item1.pk,
             permission=visibility_permission_choices.auth,
-            publication_date=(datetime.datetime.today()-datetime.timedelta(days=2)).date(),
+            publication_date=(datetime.datetime.today() - datetime.timedelta(days=2)).date(),
             publisher=self.su
         )
 
         # User is not logged in, can not see page
         response = self.client.get(self.get_page(self.item1))
         self.assertEqual(response.status_code, 403)
-        
+
         self.login_viewer()
 
         # Now logged in, can see page
@@ -2962,20 +2952,19 @@ class LoggedInViewManagedItemPages(utils.LoggedInViewPages):
         self.assertEqual(response.status_code, 200)
 
 
-
 class MeasureViewPage(LoggedInViewManagedItemPages, TestCase):
-    url_name='measure'
-    itemType=models.Measure
+    url_name = 'measure'
+    itemType = models.Measure
 
     def setUp(self):
         super().setUp()
 
-        self.item2 = models.UnitOfMeasure.objects.create(name="OC1",workgroup=self.wg1,measure=self.item1,**self.defaults)
+        self.item2 = models.UnitOfMeasure.objects.create(name="OC1", workgroup=self.wg1, measure=self.item1, **self.defaults)
 
 
 class RegistrationAuthorityViewPage(utils.LoggedInViewPages, TestCase):
-    url_name='registrationAuthority'
-    itemType=models.RegistrationAuthority
+    url_name = 'registrationAuthority'
+    itemType = models.RegistrationAuthority
 
     def setUp(self):
         super().setUp()
@@ -2985,7 +2974,7 @@ class RegistrationAuthorityViewPage(utils.LoggedInViewPages, TestCase):
             stewardship_organisation=self.steward_org_1,
         )
 
-        self.item2 = models.DataElement.objects.create(name="OC1",workgroup=self.wg1)
+        self.item2 = models.DataElement.objects.create(name="OC1", workgroup=self.wg1)
 
         models.Status.objects.create(
             concept=self.item2,
@@ -2994,10 +2983,10 @@ class RegistrationAuthorityViewPage(utils.LoggedInViewPages, TestCase):
             state=models.STATES.standard
         )
 
-    def get_page(self,item):
+    def get_page(self, item):
         return item.get_absolute_url()
 
     def test_view_all_ras(self):
         self.logout()
         response = self.client.get(reverse('aristotle:all_registration_authorities'))
-        self.assertEqual(response.status_code,200)
+        self.assertEqual(response.status_code, 200)

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/user_pages.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/user_pages.py
@@ -573,14 +573,16 @@ class CreatedItemsListView(LoginRequiredMixin, AjaxFormMixin, FormMixin, ListVie
             self.ajax_success_message = 'Share permissions updated'
 
             if 'notify_new_users_checkbox' in self.request.POST and self.request.POST['notify_new_users_checkbox']:
-                recently_added_emails = self.get_recently_added_emails(ast.literal_eval(self.state_of_emails_before_updating),
-                                                                       ast.literal_eval(self.share.emails))
+                recently_added_emails = self.get_recently_added_emails(
+                    ast.literal_eval(self.state_of_emails_before_updating),
+                    ast.literal_eval(self.share.emails)
+                )
                 if len(recently_added_emails) > 0:
-                    send_sandbox_notification_emails.delay(recently_added_emails,
-                                                           self.request.user.email,
-                                                           self.request.get_host() + reverse('aristotle_mdr:sharedSandbox',
-                                                                                             args=[self.share.uuid])
-                                                           )
+                    send_sandbox_notification_emails.delay(
+                        recently_added_emails,
+                        self.request.user.email,
+                        self.request.get_host() + reverse('aristotle_mdr:sharedSandbox', args=[self.share.uuid])
+                    )
 
         return super().form_valid(form)
 

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/views.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/views.py
@@ -580,6 +580,8 @@ class ReviewChangesView(SessionWizardView):
         ]
 
         use_celery: bool = (len(item_ids) > 1 or cascading)
+        if settings.ALWAYS_SYNC_REGISTER:
+            use_celery = False
 
         if use_celery:
             run_task_on_commit(register_items, args=register_args)

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/views.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/views.py
@@ -582,9 +582,9 @@ class ReviewChangesView(SessionWizardView):
         use_celery: bool = (len(item_ids) > 1 or cascading)
 
         if use_celery:
-            run_task_on_commit(register_items, args=args)
+            run_task_on_commit(register_items, args=register_args)
         else:
-            register_items(*args)
+            register_items(*register_args)
 
 
 class ChangeStatusView(ReviewChangesView):


### PR DESCRIPTION
This makes sure celery tasks start after the current database
transaction is complete so that item lookups can be done. The will need
to be done if future for any celery tasks run during a transaction

Util functions have been added to help with this