### PR TITLE
Fixed failure when URL query string is empty in comparator

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/actions/compare/compare_items.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/actions/compare/compare_items.html
@@ -57,6 +57,7 @@
         <div class="well">
             Both versions must be selected
         </div>
+
     {% elif cannot_compare %}
         <div class="well">
             Those versions could not be compared

--- a/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/actions/compare/compare_items.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/actions/compare/compare_items.html
@@ -17,11 +17,11 @@
 {% block content %}
     <h1>Concept comparator</h1>
     <form method="get" action="">
-        <p>
-            This form allows you to compare items.
+        <div class="well well-sm">
+            <em>This tool allows you to compare items.</em>
             Text in green below is present only in the item in that column, text in red is
             present only in the opposite column and text in white is similar across both items.
-        </p>
+        </div>
         <table class="table table-bordered compare">
             <thead>
             <tr>
@@ -37,6 +37,7 @@
                 <th></th>
             </tr>
             </thead>
+
             {% if item_a and item_b %}
             <tbody>
                 <tr>
@@ -48,16 +49,18 @@
                         </a>
                     </td>
                 </tr>
-            </tbody>
             {% endif %}
+            </tbody>
         </table>
-        <input id="compare" type="submit" class="btn btn-primary" value="Compare" />
+        <div class="container text-center">
+            <input id="compare" type="submit" class="btn btn-primary text-center" value="Compare" />
+        </div>
     </form>
+    <hr>
     {% if not_all_versions_selected %}
         <div class="well">
             Both versions must be selected
         </div>
-
     {% elif cannot_compare %}
         <div class="well">
             Those versions could not be compared

--- a/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_comparator.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/tests/main/test_comparator.py
@@ -2,122 +2,26 @@ from django.test import TestCase
 
 import aristotle_mdr.models as models
 import aristotle_mdr.tests.utils as utils
-from django.urls import reverse
-from django.utils import timezone
-
-from reversion import revisions as reversion
-from unittest import skip
 
 
 class ComparatorTester(utils.LoggedInViewPages):
-
     def setUp(self):
         super().setUp()
         self.steward_org_1 = models.StewardOrganisation.objects.create(name="Test SO")
+
         self.ra = models.RegistrationAuthority.objects.create(name="Test RA", stewardship_organisation=self.steward_org_1)
+
         self.wg = models.Workgroup.objects.create(name="Setup WG", stewardship_organisation=self.steward_org_1)
+
         self.item1 = self.itemType.objects.create(name="Item with a name", workgroup=self.wg)
-        self.item2 = self.itemType.objects.create(name="Item wit a different name", workgroup=self.wg)
 
-    @skip('Concept comparator temporarily disabled')
-    def test_compare_page_loads(self):
-        self.logout()
-        item1 = self.item1
-        item2 = self.item2
-        response = self.client.get(
-            reverse('aristotle:compare_concepts') + "?item_a=%s&item_b=%s" % (item1.id, item2.id)
-        )
-        self.assertEqual(response.status_code, 200)
-        form = response.context['form']
-        self.assertTrue('Select a valid choice', form.errors['item_a'][0])
-        self.assertTrue('Select a valid choice', form.errors['item_b'][0])
-        # register items so they are now visible
-        s = models.Status.objects.create(
-            concept=item1,
-            registrationAuthority=self.ra,
-            registrationDate=timezone.now(),
-            state=self.ra.public_state
-        )
+        self.item2 = self.itemType.objects.create(name="Item with a different name", workgroup=self.wg)
 
-        response = self.client.get(
-            reverse('aristotle:compare_concepts') + "?item_a=%s&item_b=%s" % (item1.id, item2.id)
-        )
-        self.assertEqual(response.status_code, 200)
-        form = response.context['form']
-        self.assertTrue('Select a valid choice', form.errors['item_b'][0])
-        self.assertTrue('item_a' not in form.errors.keys())  # No error will show as we need two choices
+    def test_compare_with_no_selections_shows_blank_form(self):
+        pass
 
-        models.Status.objects.create(
-            concept=item2,
-            registrationAuthority=self.ra,
-            registrationDate=timezone.now(),
-            state=self.ra.public_state
-        )
-        item1 = self.itemType.objects.get(pk=item1.pk)  # decache
-        item2 = self.itemType.objects.get(pk=item2.pk)  # decache
+    def test_user_without_permission_cant_compare_items(self):
+        pass
 
-        self.assertTrue(item1.is_public())
-        self.assertTrue(item2.is_public())
-        response = self.client.get(
-            reverse('aristotle:compare_concepts') + "?item_a=%s&item_b=%s" % (item1.id, item2.id)
-        )
-        self.assertEqual(response.status_code, 200)
-        form = response.context['form']
-
-        self.assertTrue('This item has no revisions', form.errors['item_a'][0])
-        self.assertTrue('This item has no revisions', form.errors['item_b'][0])
-
-        with reversion.create_revision():
-            item1.definition = "bump to make a reversion"
-            item1.save()
-        with reversion.create_revision():
-            item2.definition = "bump to make a reversion"
-            item2.save()
-
-        response = self.client.get(
-            reverse('aristotle:compare_concepts') + "?item_a=%s&item_b=%s" % (item1.id, item2.id)
-        )
-        self.assertEqual(response.status_code, 200)
-        form = response.context['form']
-
-        self.assertTrue('item_a' not in form.errors.keys())
-        self.assertTrue('item_b' not in form.errors.keys())
-        self.assertContains(response, '>different </ins')  # check that we have made a diff
-
-        same = response.context['same']
-        self.assertTrue('definition' in same.keys())  # check that we have made a diff
-        self.assertTrue('bump to make a reversion' in same['definition']['value'])  # check that we have made a diff
-
-
-class ObjectClassComparatorTester(ComparatorTester, TestCase):
-    itemType=models.ObjectClass
-
-
-class ValueDomainComparatorTester(ComparatorTester, TestCase):
-    itemType=models.ValueDomain
-
-    def setUp(self):
-        super().setUp()
-
-        for i in range(4):
-            models.PermissibleValue.objects.create(
-                value=i,
-                meaning="test permissible meaning %d" % i,
-                order=i,
-                valueDomain=self.item1
-            )
-        for i, j in zip(range(3), range(3)):
-            # give the item 2 object classes an offset
-            models.PermissibleValue.objects.create(
-                value=i + j,
-                meaning="test permissible meaning %d" % i,
-                order=i,
-                valueDomain=self.item2
-            )
-        for i in range(2):
-            models.SupplementaryValue.objects.create(
-                value=i,
-                meaning="test supplementary meaning %d" % i,
-                order=i,
-                valueDomain=self.item1
-            )
+    def test_concept_with_no_version_handled(self):
+        pass

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/comparator.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/comparator.py
@@ -83,7 +83,7 @@ class MetadataComparison(ConceptVersionCompareBase, AristotleMetadataToolView):
 
         if self.get_version_1_concept() is None and self.get_version_2_concept() is None:
             # Not all concepts selected
-            self.context['form']  = self.get_form()
+            self.context['form'] = self.get_form()
             return self.context
 
         self.context.update({

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/comparator.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/comparator.py
@@ -79,7 +79,8 @@ class MetadataComparison(ConceptVersionCompareBase, AristotleMetadataToolView):
 
     def apply_permission_checking(self, version_permission_1, version_permission_2):
         # We're not checking the version permissions because we are getting the most recent version and we have already
-        # checked that the user can view the item so the 'content' viewed is the same
+        # checked that the user can view the item so the 'content' viewed is the same.
+        # TODO: rethink how VersionPermissions work
         pass
 
     def get_compare_versions(self):
@@ -89,10 +90,14 @@ class MetadataComparison(ConceptVersionCompareBase, AristotleMetadataToolView):
         if not concept_1 or not concept_2:
             return None, None
 
-        version_1 = Version.objects.get_for_object(concept_1).order_by('-revision__date_created').first().pk
-        version_2 = Version.objects.get_for_object(concept_2).order_by('-revision__date_created').first().pk
+        try:
+            version_1 = Version.objects.get_for_object(concept_1).order_by('-revision__date_created').first().pk
+            version_2 = Version.objects.get_for_object(concept_2).order_by('-revision__date_created').first().pk
+        except AttributeError:
+            self.context['cannot_compare'] = True
+            return None, None
 
-        return (version_1, version_2)
+        return version_1, version_2
 
     def get_context_data(self, **kwargs):
         self.context = super().get_context_data(**kwargs)

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/comparator.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/comparator.py
@@ -31,6 +31,7 @@ class MetadataComparison(ConceptVersionCompareBase, AristotleMetadataToolView):
     def has_same_base_model(self):
         concept_1 = self.get_version_1_concept()
         concept_2 = self.get_version_2_concept()
+
         return concept_1._meta.model == concept_2._meta.model
 
     def get_subitem_key(self, subitem_model):
@@ -74,10 +75,17 @@ class MetadataComparison(ConceptVersionCompareBase, AristotleMetadataToolView):
 
         version_1 = Version.objects.get_for_object(concept_1).order_by('-revision__date_created').first().pk
         version_2 = Version.objects.get_for_object(concept_2).order_by('-revision__date_created').first().pk
+
         return (version_1, version_2)
 
     def get_context_data(self, **kwargs):
         self.context = super().get_context_data(**kwargs)
+
+        if self.get_version_1_concept() is None and self.get_version_2_concept() is None:
+            # Not all concepts selected
+            self.context['form']  = self.get_form()
+            return self.context
+
         self.context.update({
             "form": self.get_form(),
             "has_same_base_model": self.has_same_base_model,

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/versions.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/versions.py
@@ -36,6 +36,7 @@ class VersionsMixin:
 
     def user_can_view_version(self, user, metadata_item, version_permission: VersionPermissions) -> bool:
         """ Determine whether or not user can view the specific version """
+
         in_workgroup = metadata_item.workgroup and user in metadata_item.workgroup.member_list
         authenticated_user = not user.is_anonymous()
 

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/versions.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/versions.py
@@ -443,9 +443,8 @@ class ConceptVersionCompareBase(VersionsMixin, TemplateView):
 
         DiffMatchPatch = diff_match_patch.diff_match_patch()
         field_to_diff = {}
-        field_names = [
-            f.name for f in self.model._meta.get_fields()
-        ] + [
+
+        field_names = [f.name for f in self.model._meta.get_fields()] + [
             'customvalue_set', 'slots', 'identifiers', 'org_records',
         ]
 
@@ -687,8 +686,6 @@ class ConceptVersionCompareBase(VersionsMixin, TemplateView):
 
         self.context['activetab'] = 'history'
         self.context['hide_item_actions'] = True
-
-        # self.concept: MDR._concept = self.get_item(self.request.user).item
 
         version_1, version_2 = self.get_compare_versions()
 


### PR DESCRIPTION
Fixes issues: #

Sanity checks:
- [ ] Have tests been run locally?
- [ ] Does this change any javascript? If so, have you checked that the UI works as expected?
- [ ] If there are data model changes, are relevant data standards referenced - in code?
- [ ] If there are deviations from any specified standards, are the reasons for changes documented?
- [ ] If there are UI changes have you documented whats changed so the help documentation can be updated?
