### PR TITLE
Fix for indicator, relation item pages 500ing when /related/ accessed

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/models.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/models.py
@@ -758,7 +758,7 @@ class _concept(baseAristotleObject):
     # enabled
     backwards_compatible_fields: List[str] = []
     registerable = True
-    relational_attributes: Dict[str, Dict]
+    relational_attributes: Dict[str, Dict] = {}
     # Used by concept manager with_related in a select_related
     related_objects: List[str] = []
     # Fields to build the name from

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/tools.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/tools.py
@@ -11,7 +11,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-
 class ItemGraphView(SimpleItemGet, TemplateView):
     model = MDR._concept
     template_name = "aristotle_mdr/graphs/item_graphs.html"

--- a/python/aristotle-metadata-registry/aristotle_mdr/views/tools.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/tools.py
@@ -5,11 +5,6 @@ from aristotle_mdr import models as MDR
 from aristotle_mdr.views.utils import SimpleItemGet, paginate_sort_opts
 from aristotle_mdr.utils import is_active_extension
 
-from typing import List
-
-import logging
-logger = logging.getLogger(__name__)
-
 
 class ItemGraphView(SimpleItemGet, TemplateView):
     model = MDR._concept


### PR DESCRIPTION
Fixes issues: #

Sanity checks:
- [ ] Have tests been run locally?
- [ ] Does this change any javascript? If so, have you checked that the UI works as expected?
- [ ] If there are data model changes, are relevant data standards referenced - in code?
- [ ] If there are deviations from any specified standards, are the reasons for changes documented?
- [ ] If there are UI changes have you documented whats changed so the help documentation can be updated?
