### PR TITLE
Fixed comet help page 500ing when template doesn't exist

### DIFF
--- a/python/comet-indicator-registry/comet/templates/comet/static/about_comet_mdr.html
+++ b/python/comet-indicator-registry/comet/templates/comet/static/about_comet_mdr.html
@@ -6,11 +6,11 @@
 <div clas="row">
 <h1><a href="#">Comet Indicator Registry</a></h1>
 
-<p>The Comet Indicator Registry is an extension set for the <a href="https://github.com/LegoStormtroopr/aristotle-metadata-registry">Aristotle MetaData Registry</a>
+<p>The Comet Indicator Registry is an extension set for the <a href="https://www.aristotlemetadata.com/">Aristotle MetaData Registry</a>
 that provides additional items necessary for tracking the performance of entities in the health context.
 </p>
 
-<p><b>Comet</b> adds the following <a href='{% url "aristotle:about" template="administeditems" %}'>administed items</a>:
+<p><b>Comet</b> adds the following administered items:
 <ul>
     <li>
         <a href='{% url "comet:about" template="indicator" %}'>Indicators</a>
@@ -26,10 +26,10 @@ that provides additional items necessary for tracking the performance of entitie
     </li>
 </ul>
 
-<b>Comet</b> also adds the following <a href='{% url "aristotle:about" template="unmanagedItems" %}'>unmanaged items</a>:
+<b>Comet</b> also adds the following unmanaged items:
 <ul>
      <li>
-        <a href=''>Frameworks</a>
+        Frameworks
     </li>
 </ul>
 </p>

--- a/python/comet-indicator-registry/comet/templates/comet/static/framework.html
+++ b/python/comet-indicator-registry/comet/templates/comet/static/framework.html
@@ -5,6 +5,5 @@
 
 {% block description %}
     <p>A conceptual framework which provides struture or support for a topic, concept, facts or ideas. A framework provides parameters within which an idea can be explored, expanded and documented over time. A conceptual framework is constructed through the connection of narrow dimensions to broad dimensions, forming hierarchical parent-child relationships between related concepts. </P>
-    <P>A framework or framework dimension can stand alone, or can be related to one or many indicators.</P>
-
+    <p>A framework or framework dimension can stand alone, or can be related to one or many indicators.</p>
 {% endblock %}

--- a/python/comet-indicator-registry/comet/templates/comet/static/qualitystatement.html
+++ b/python/comet-indicator-registry/comet/templates/comet/static/qualitystatement.html
@@ -1,7 +1,7 @@
 {% extends "comet/static/about_comet_item_base.html" %}
 
-{% block title %}About: Framework {% endblock %}
-{% block item_name %}Framework{% endblock %}
+{% block title %}About: Data Quality Statement {% endblock %}
+{% block item_name %}Data Quality Statement{% endblock %}
 
 {% block description %}
     <p> Data Quality Statement records any known issues that may be related to a data asset.

--- a/python/comet-indicator-registry/comet/templates/comet/static/qualitystatement.html
+++ b/python/comet-indicator-registry/comet/templates/comet/static/qualitystatement.html
@@ -1,0 +1,10 @@
+{% extends "comet/static/about_comet_item_base.html" %}
+
+{% block title %}About: Framework {% endblock %}
+{% block item_name %}Framework{% endblock %}
+
+{% block description %}
+    <p> Data Quality Statement records any known issues that may be related to a data asset.
+        A Data Quality Statement assesses data against seven key factors: Institutional Environment,
+        Relevance, Timeliness, Accuracy, Coherence, Interpretability & Accessibility. </p>
+{% endblock %}


### PR DESCRIPTION
Fixes issues: #

Sanity checks:
- [ ] Have tests been run locally?
- [ ] Does this change any javascript? If so, have you checked that the UI works as expected?
- [ ] If there are data model changes, are relevant data standards referenced - in code?
- [ ] If there are deviations from any specified standards, are the reasons for changes documented?
- [ ] If there are UI changes have you documented whats changed so the help documentation can be updated?
