### PR TITLE
Ignore migrations directories for python linting

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,3 +4,9 @@ strict_optional = False
 
 [mypy-*.tests.*]
 ignore_errors = True
+
+[mypy-*.migrations.*]
+ignore_errors = True
+
+[mypy-*.migrations_old.*]
+ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ ignore =
     W605,  # We're getting some weird false-positives (check google 'flake8 W605' for more details)
 exclude =
     migrations,
+    migrations_old,
     vendor,
     tests,
     example_mdr


### PR DESCRIPTION
Pulling into 3.1.0 feature branch, since this impacts #1554 