### PR TITLE
Remove critical log for celery result

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/views/downloads.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/views/downloads.py
@@ -159,7 +159,6 @@ class DownloadStatusView(View):
             'file_details': {}
         }
         if job.ready():
-            logger.critical(job.result)
             if job.state == 'SUCCESS':
                 context['result'] = job.result
             context['is_ready'] = True


### PR DESCRIPTION
This was removed as it was coming through sentry and probably was meant
for debugging only