### PR TITLE
Fix page numbering for small downloads

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/aristotle_pdf/downloader.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/aristotle_pdf/downloader.py
@@ -137,12 +137,14 @@ class PDFDownloader(GenericPDFDownloader):
     download_type = "pdf"
 
     default_wk_options = {
-        '--page-offset': -1,  # Make the table of contents start at 1
         '--margin-top': '10mm',
         '--margin-bottom': '5mm',
     }
 
     preamble_template = 'aristotle_mdr/downloads/pdf/title.html'
+    # Footer used when cover page is on
+    cover_footer_template = 'aristotle_mdr/downloads/html/cover_footer.html'
+    # Standard footer
     footer_template = 'aristotle_mdr/downloads/html/footer.html'
 
     def __init__(self, *args, **kwargs):
@@ -150,16 +152,20 @@ class PDFDownloader(GenericPDFDownloader):
 
         # Set dynamic options
         self.wk_options = self.default_wk_options.copy()
-        # Get path to footer template
-        footer_template_path = os.path.join(settings.MDR_BASE_DIR, 'templates', self.footer_template)
-        self.wk_options['--footer-html'] = os.path.abspath(footer_template_path)
+        # Get path to footer templates
+        self.cover_footer_path = os.path.abspath(
+            os.path.join(settings.MDR_BASE_DIR, 'templates', self.cover_footer_template)
+        )
+        self.footer_path = os.path.abspath(
+            os.path.join(settings.MDR_BASE_DIR, 'templates', self.footer_template)
+        )
 
         # Set pdf page size
         aristotle_settings = fetch_aristotle_settings()
         if 'DOWNLOAD_OPTIONS' in aristotle_settings:
             self.wk_options['--page-size'] = aristotle_settings['DOWNLOAD_OPTIONS'].get('PDF_PAGE_SIZE', 'A4')
 
-        # Create configuration object so we can ser wkhtmltopdf binary location
+        # Create configuration object so we can set wkhtmltopdf binary location
         if settings.WKHTMLTOPDF_LOCATION is not None:
             self.wk_config = pdfkit.configuration(wkhtmltopdf=settings.WKHTMLTOPDF_LOCATION)
         else:
@@ -180,7 +186,7 @@ class PDFDownloader(GenericPDFDownloader):
         title_temp_file = None
         cover = None
 
-        # If we are making a title, write to temp file
+        # If we are making a title
         if table_of_contents:
             # Add toc option so toc is generated
             toc_options['--toc-header-text'] = 'Table Of Contents'
@@ -191,6 +197,13 @@ class PDFDownloader(GenericPDFDownloader):
             title_temp_file.write(preamble_string.encode('utf-8'))
             # Set cover
             cover = title_temp_file.name
+            # Set options for fixing page numbers with 2 page cover
+            final_options['--page-offset'] = -1
+            final_options['--footer-html'] = self.cover_footer_path
+        else:
+            # If there is no cover / toc use standard footer
+            # otherwise page numbers will be incorrect
+            final_options['--footer-html'] = self.footer_path
 
         # Convert to pdf
         pdf: bytes = pdfkit.from_string(
@@ -199,7 +212,7 @@ class PDFDownloader(GenericPDFDownloader):
             cover=cover,
             cover_first=True,
             configuration=self.wk_config,
-            options=self.wk_options,
+            options=final_options,
             toc=toc_options
         )
 

--- a/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/downloads/html/cover_footer.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/templates/aristotle_mdr/downloads/html/cover_footer.html
@@ -35,7 +35,7 @@
       }
 
       // Replace innerText of elements with queryString values
-      function processValues(values) {
+      function processValues(values, processor) {
         for (var i in values) {
           var val = values[i]
           // If value in query params
@@ -46,6 +46,10 @@
             for (var j in elements) {
               var element = elements[j]
               var value = queryParams[val]
+              // Pass value through processor function
+              if (processor !== undefined) {
+                value = processor(value)
+              }
               element.innerText = value
             }
           }
@@ -53,8 +57,13 @@
       }
 
       // Values to look for in params (only the ones we use for efficiency)
-      var values = ['page', 'topage']
+      var values = ['topage']
+      // Need to decrement this since our header is 2 pages and it assumes 1
+      // but topage is correct
+      var decrementValues = ['page']
+
       processValues(values)
+      processValues(decrementValues, function(i) { return i - 1 })
 
     </script>
   </body>


### PR DESCRIPTION
Downloads without a cover page and table of contents had incorrect page
numbering due to numbering changes required to deal with those leading
pages