### PR TITLE
Fixed custom field enum values incorrectly displaying as 'old' even if they weren't

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/custom_fields/forms.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/custom_fields/forms.py
@@ -86,7 +86,6 @@ class CustomValueFormMixin:
                 csvReader = csv.reader(values.split('\n'))
                 # Get a list of lists from csv reader
                 choice_lists = [value for value in csvReader]
-                logger.critical(f'choice list is {choice_lists}')
                 # Flatten into list of values
                 choice_values = list(itertools.chain(*choice_lists))
                 # Make into 2 tuple

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/custom_fields/forms.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/custom_fields/forms.py
@@ -54,6 +54,9 @@ class CustomValueFormMixin:
     cleaned_data: dict
 
     def __init__(self, custom_fields: Iterable[CustomField] = [], **kwargs):
+        import logging
+        logger = logging.getLogger(__name__)
+
         # This is immediately overridden by __init__ but python type checking demands it
         self.bad_value_custom_fields: Set = set()
         self.initial: Dict
@@ -82,22 +85,19 @@ class CustomValueFormMixin:
                 # Parse lines with csv reader
                 csvReader = csv.reader(values.split('\n'))
                 # Get a list of lists from csv reader
-                choice_lists = [v for v in csvReader]
+                choice_lists = [value for value in csvReader]
+                logger.critical(f'choice list is {choice_lists}')
                 # Flatten into list of values
-                choice_values = itertools.chain(*choice_lists)
+                choice_values = list(itertools.chain(*choice_lists))
                 # Make into 2 tuple
                 choices = [('', '------')]
                 for val in choice_values:
                     choices.append((val, val))
 
-                import logging
-
-                logger = logging.getLogger(__name__)
-
                 if custom_fname in self.initial:
                     value = self.initial[custom_fname]
                     if value and value not in choice_values:
-                        # If there is an initial value that isnt in the option list
+                        # If there is an initial value that isn't in the option list
                         # Add it as the last option
                         choices.append((value, value + ' (Old Value)'))
                         self.bad_value_custom_fields.add(custom_fname)

--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/custom_fields/forms.py
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/custom_fields/forms.py
@@ -54,9 +54,6 @@ class CustomValueFormMixin:
     cleaned_data: dict
 
     def __init__(self, custom_fields: Iterable[CustomField] = [], **kwargs):
-        import logging
-        logger = logging.getLogger(__name__)
-
         # This is immediately overridden by __init__ but python type checking demands it
         self.bad_value_custom_fields: Set = set()
         self.initial: Dict


### PR DESCRIPTION
Issues resolved: #

Sanity checks:
- [ ] Have tests been run locally?
- [ ] Does this change any javascript? If so, have you checked that the UI works as expected?
- [ ] If there are data model changes, are relevant data standards referenced - in code?
- [ ] If there are deviations from any specified standards, are the reasons for changes documented?
- [ ] If there are UI changes have you documented whats changed so the help documentation can be updated?
