### PR TITLE
Fixed breadcrumbs spacing being unnecessarily wide on metadata browse

### DIFF
--- a/python/aristotle-metadata-registry/aristotle_mdr/contrib/browse/templates/aristotle_mdr_browse/apps_list.html
+++ b/python/aristotle-metadata-registry/aristotle_mdr/contrib/browse/templates/aristotle_mdr_browse/apps_list.html
@@ -2,11 +2,9 @@
 {% load aristotle_tags aristotle_help util_tags %}
 
 {% block breadcumbs %}
-    <ul class="breadcrumb">
     <li><a href="{% url 'aristotle_mdr:home' %}">Home</a></li>
     <li><a href="{% url 'browse' %}">Main browser</a></li>
     <li class="active">Metadata browser</li>
-</ul>
 {% endblock %}
 {% block title %}Concept browser{% endblock %}
 


### PR DESCRIPTION
Issues resolved: #

Sanity checks:
- [ ] Have tests been run locally?
- [ ] Does this change any javascript? If so, have you checked that the UI works as expected?
- [ ] If there are data model changes, are relevant data standards referenced - in code?
- [ ] If there are deviations from any specified standards, are the reasons for changes documented?
- [ ] If there are UI changes have you documented whats changed so the help documentation can be updated?
